### PR TITLE
CLOUD-3623 - Template eap-xp1-third-party-db-s2i is missing ${APPLICATION_NAME} service

### DIFF
--- a/templates/eap-xp1-third-party-db-s2i.json
+++ b/templates/eap-xp1-third-party-db-s2i.json
@@ -220,7 +220,6 @@
         }
     ],
     "objects": [
-
         {
             "kind": "Service",
             "apiVersion": "v1",
@@ -236,7 +235,7 @@
                 }
             },
             "metadata": {
-                "name": "secure-${APPLICATION_NAME}",
+                "name": "${APPLICATION_NAME}",
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-3623
Signed-off-by: Ken Wills <kwills@redhat.com>
