### PR TITLE
[CLOUD-3630] Remove default value for GALLEON_PROVISION_LAYERS env

### DIFF
--- a/templates/eap-xp1-basic-s2i.json
+++ b/templates/eap-xp1-basic-s2i.json
@@ -67,7 +67,6 @@
             "displayName": "Galleon layers",
             "description": "Comma separated list of Galleon layers to provision a server.",
             "name": "GALLEON_PROVISION_LAYERS",
-            "value": "jaxrs-server",
             "required": false
         },
         {


### PR DESCRIPTION
The EAP XP 1.0 templates do not need a default value for the
GALLEON_PROVISION_LAYERS env var.

JIRA: https://issues.redhat.com/browse/CLOUD-3630

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>