### PR TITLE
[CLOUD-3918] EAP 7.4.0.Beta imagestreams

### DIFF
--- a/eap74-beta-openjdk8-image-stream.json
+++ b/eap74-beta-openjdk8-image-stream.json
@@ -13,7 +13,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-openjdk8-openshift",
+                "name": "jboss-eap74-beta-openjdk8-openshift",
                 "annotations": {
                     "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -53,7 +53,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-beta-runtime-openshift",
+                "name": "jboss-eap74-beta-openjdk8-runtime-openshift",
                 "annotations": {
                     "openshift.io/display-name": "JBoss EAP 7.4.0.Beta Runtime Image with OpenJDK 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",


### PR DESCRIPTION
Fix names of imagestreams for EAP 7.4.0.Beta / JDK8 images

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>