### PR TITLE
[CLOUD-3839] Prepare imagestreams and templates for EAP 7.4 GA

### DIFF
--- a/eap74-openj9-11-image-stream.json
+++ b/eap74-openj9-11-image-stream.json
@@ -2,9 +2,9 @@
     "kind": "List",
     "apiVersion": "v1",
     "metadata": {
-        "name": "jboss74-beta-openj9-image-streams",
+        "name": "jboss-eap74-openj9-11-openshift-image-streams",
         "annotations": {
-            "description": "JBoss EAP 7.4.0.Beta imagestream for OpenShift to build and run Jakarta EE applications on RHEL8 with OpenJDK 11 and using the OpenJ9 JVM",
+            "description": "JBoss EAP 7.4.0 imagestream for OpenShift to build and run Jakarta EE applications on RHEL8 with OpenJDK 11 and using the OpenJ9 JVM",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -13,37 +13,37 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-beta-openj9-11-openshift",
+                "name": "jboss-eap74-openj9-11-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK11 + OpenJ9",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK11 + OpenJ9",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.0.Beta"
+                    "version": "7.4.0"
                 }
             },
             "labels": {
-                "xpaas": "7.4.0.Beta"
+                "xpaas": "7.4.0"
             },
             "spec": {
                 "tags": [
                     {
-                        "name": "7.4.0.Beta",
+                        "name": "7.4.0",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4.0.Beta with OpenJDK 11 + OpenJ9",
+                            "description": "The latest available build of JBoss EAP 7.4.0 with OpenJDK 11 + OpenJ9",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.4.0.Beta,javaee:8,java:11",
+                            "supports": "eap:7.4.0,javaee:8,java:11",
                             "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK11 + OpenJ9"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK11 + OpenJ9"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7-tech-preview/eap74-openj9-11-openshift-rhel8"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openj9-11-openshift-rhel8"
                         }
                     }
                 ]
@@ -53,37 +53,37 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-beta-openj9-11-runtime-openshift",
+                "name": "jboss-eap74-openj9-11-runtime-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0.Beta Runtime Image with OpenJDK11 + OpenJ9",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK11 + OpenJ9",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.0.Beta"
+                    "version": "7.4.0"
                 }
             },
             "labels": {
-                "xpaas": "7.4.0.Beta"
+                "xpaas": "7.4.0"
             },
             "spec": {
                 "tags": [
                     {
-                        "name": "7.4.0.Beta",
+                        "name": "7.4.0",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4.0.Beta runtime image with OpenJDK11 + OpenJ9",
+                            "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK11 + OpenJ9",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.4.0.Beta,javaee:8,java:11",
+                            "supports": "eap:7.4.0,javaee:8,java:11",
                             "sampleRepo": "https://github.com/jbossas/eap-quickstarts",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK11 + OpenJ9 (Runtime Image)"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK11 + OpenJ9 (Runtime Image)"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7-tech-preview/eap74-openj9-11-runtime-openshift-rhel8"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openj9-11-runtime-openshift-rhel8"
                         }
                     }                ]
             }

--- a/eap74-openjdk11-image-stream.json
+++ b/eap74-openjdk11-image-stream.json
@@ -2,9 +2,9 @@
     "kind": "List",
     "apiVersion": "v1",
     "metadata": {
-        "name": "jboss74-beta-openjdk11-image-streams",
+        "name": "jboss-eap74-openjdk11-openshift-image-streams",
         "annotations": {
-            "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0.Beta with OpenJDK 11.",
+            "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0 with OpenJDK 11.",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -13,37 +13,37 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-beta-openjdk11-openshift",
+                "name": "jboss-eap74-openjdk11-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK 11",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 11",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.0.Beta"
+                    "version": "7.4.0"
                 }
             },
             "labels": {
-                "xpaas": "7.4.0.Beta"
+                "xpaas": "7.4.0"
             },
             "spec": {
                 "tags": [
                     {
-                        "name": "7.4.0.Beta",
+                        "name": "7.4.0",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4.0.Beta with OpenJDK 11.",
+                            "description": "The latest available build of JBoss EAP 7.4.0 with OpenJDK 11.",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.4.0.Beta,javaee:8,java:11",
+                            "supports": "eap:7.4.0,javaee:8,java:11",
                             "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK11"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK11"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-openshift-rhel8"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk11-openshift-rhel8"
                         }
                     }
                 ]
@@ -53,37 +53,37 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-beta-openjdk11-runtime-openshift",
+                "name": "jboss-eap74-openjdk11-runtime-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0.Beta Runtime Image with OpenJDK 11",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK 11",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.0.Beta"
+                    "version": "7.4.0"
                 }
             },
             "labels": {
-                "xpaas": "7.4.0.Beta"
+                "xpaas": "7.4.0"
             },
             "spec": {
                 "tags": [
                     {
-                        "name": "7.4.0.Beta",
+                        "name": "7.4.0",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4.0.Beta runtime image with OpenJDK 11",
+                            "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 11",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.4.0.Beta,javaee:8,java:11",
+                            "supports": "eap:7.4.0,javaee:8,java:11",
                             "sampleRepo": "https://github.com/jbossas/eap-quickstarts",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK 11 (Runtime Image)"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 11 (Runtime Image)"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk11-runtime-openshift-rhel8"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk11-runtime-openshift-rhel8"
                         }
                     }
                 ]

--- a/eap74-openjdk8-image-stream.json
+++ b/eap74-openjdk8-image-stream.json
@@ -2,9 +2,9 @@
     "kind": "List",
     "apiVersion": "v1",
     "metadata": {
-        "name": "jboss74-beta-openjdk8-image-streams",
+        "name": "jjboss-eap74-openjdk8-openshift-image-streams",
         "annotations": {
-            "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0.Beta with OpenJDK 8",
+            "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0 with OpenJDK 8",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -13,37 +13,37 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-beta-openjdk8-openshift",
+                "name": "jboss-eap74-openjdk8-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK 8",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.0.Beta"
+                    "version": "7.4.0"
                 }
             },
             "labels": {
-                "xpaas": "7.4.0.Beta"
+                "xpaas": "7.4.0"
             },
             "spec": {
                 "tags": [
                     {
-                        "name": "7.4.0.Beta",
+                        "name": "7.4.0",
                         "annotations": {
-                            "description": "JBoss EAP 7.4.0.Beta",
+                            "description": "JBoss EAP 7.4.0",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.4.0.Beta,javaee:8,java:8",
+                            "supports": "eap:7.4.0,javaee:8,java:8",
                             "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK8"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK8"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk8-openshift-rhel8:latest"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
                         }
                     }
                 ]
@@ -53,37 +53,37 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "jboss-eap74-beta-openjdk8-runtime-openshift",
+                "name": "jboss-eap74-openjdk8-runtime-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0.Beta Runtime Image with OpenJDK 8",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "7.4.0.Beta"
+                    "version": "7.4.0"
                 }
             },
             "labels": {
-                "xpaas": "7.4.0.Beta"
+                "xpaas": "7.4.0"
             },
             "spec": {
                 "tags": [
                     {
-                        "name": "7.4.0.Beta",
+                        "name": "7.4.0",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4.0.Beta runtime image with OpenJDK 8",
+                            "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 8",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
-                            "supports": "eap:7.4.0.Beta,javaee:8,java:8",
+                            "supports": "eap:7.4.0,javaee:8,java:8",
                             "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with OpenJDK 8 (Runtime Image)"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 (Runtime Image)"
                         },
                         "referencePolicy": {
                             "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7-tech-preview/eap74-openjdk8-runtime-openshift-rhel7:latest"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel7:latest"
                         }
                     }
                 ]

--- a/templates/eap74-amq-persistent-s2i.json
+++ b/templates/eap74-amq-persistent-s2i.json
@@ -4,22 +4,22 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
-            "tags": "eap,javaee,java,jboss,hidden",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta + AMQ 7 with passthrough TLS",
+            "tags": "eap,javaee,java,jboss",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0 + AMQ 7 with passthrough TLS",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application using Red Hat JBoss AMQ. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc",
-            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform continuous delivery based application, including a build configuration, application deployment configuration, using Red Hat JBoss AMQ and secure communication using passthrough TLS.",
+            "description": "An example JBoss Enterprise Application Platform application using Red Hat JBoss AMQ with persistence and secure communication using https. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc",
+            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration, using Red Hat JBoss AMQ with persistence and secure communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-amq-s2i"
+        "name": "eap74-amq-persistent-s2i"
     },
     "labels": {
-        "template": "eap74-beta-amq-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-amq-persistent-s2i",
+        "xpaas": "7.4.0"
     },
-    "message": "A new JBoss EAP and AMQ 7 based application with SSL support has been created in your project. The username/password for accessing the AMQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "message": "A new JBoss EAP and AMQ persistent based application with SSL support has been created in your project. The username/password for accessing the AMQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,16 +30,16 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:latest",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:latest",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "required": true
         },
         {
@@ -84,10 +84,24 @@
             "required": false
         },
         {
+            "displayName": "AMQ Volume Size",
+            "description": "Size of the volume used by AMQ for persisting messages.",
+            "name": "VOLUME_CAPACITY",
+            "value": "1Gi",
+            "required": true
+        },
+        {
             "displayName": "JMS Connection Factory JNDI Name",
             "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:jboss/DefaultJMSConnectionFactory",
             "name": "MQ_JNDI",
             "value": "java:jboss/DefaultJMSConnectionFactory",
+            "required": false
+        },
+        {
+            "displayName": "Split the data directory?",
+            "description": "Split the data directory for each node in a mesh.",
+            "name": "AMQ_SPLIT",
+            "value": "false",
             "required": false
         },
         {
@@ -123,7 +137,7 @@
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": true
+            "required": false
         },
         {
             "displayName": "Server Keystore Filename",
@@ -266,7 +280,7 @@
             "displayName": "Maven Additional Arguments",
             "description": "Maven additional arguments to use for S2I builds",
             "name": "MAVEN_ARGS_APPEND",
-            "value": "-Dcom.redhat.xpaas.repo.jbossorg",
+            "value": "-Dcom.redhat.xpaas.repo.jbossorg",            
             "required": false
         },
         {
@@ -740,10 +754,6 @@
                                         "value": "${MQ_PASSWORD}"
                                     },
                                     {
-                                        "name": "MQ_ROLE",
-                                        "value": "${MQ_ROLE}"
-                                    },
-                                    {
                                         "name": "MQ_PROTOCOL",
                                         "value": "tcp"
                                     },
@@ -855,7 +865,10 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Rolling",
+                    "rollingParams": {
+                        "maxSurge": 0
+                    }
                 },
                 "triggers": [
                     {
@@ -946,6 +959,12 @@
                                         "protocol": "TCP"
                                     }
                                 ],
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/opt/amq/data/kahadb",
+                                        "name": "${APPLICATION_NAME}-amq-pvol"
+                                    }
+                                ],
                                 "env": [
                                     {
                                         "name": "AMQ_USER",
@@ -954,6 +973,10 @@
                                     {
                                         "name": "AMQ_PASSWORD",
                                         "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_ROLE",
+                                        "value": "${MQ_ROLE}"
                                     },
                                     {
                                         "name": "AMQ_TRANSPORTS",
@@ -970,6 +993,10 @@
                                     {
                                         "name": "MQ_SERIALIZABLE_PACKAGES",
                                         "value": "${MQ_SERIALIZABLE_PACKAGES}"
+                                    },
+                                    {
+                                        "name": "AMQ_SPLIT",
+                                        "value": "${AMQ_SPLIT}"
                                     },
                                     {
                                         "name": "AMQ_MESH_DISCOVERY_TYPE",
@@ -993,7 +1020,35 @@
                                     }
                                 ]
                             }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "${APPLICATION_NAME}-amq-pvol",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${APPLICATION_NAME}-amq-claim"
+                                }
+                            }
                         ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-claim",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${VOLUME_CAPACITY}"
                     }
                 }
             }

--- a/templates/eap74-amq-s2i.json
+++ b/templates/eap74-amq-s2i.json
@@ -4,22 +4,22 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
-            "tags": "eap,javaee,java,jboss",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with passthrough TLS & DB driver examples",
+            "tags": "eap,javaee,java,jboss,hidden",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0 + AMQ 7 with passthrough TLS",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop JBoss Enterprise Application Server based application, including a build configuration, application deployment configuration, using third-party DB drivers and secure communication using passthrough TLS.",
+            "description": "An example JBoss Enterprise Application Platform application using Red Hat JBoss AMQ. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc",
+            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform continuous delivery based application, including a build configuration, application deployment configuration, using Red Hat JBoss AMQ and secure communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-third-party-db-s2i"
+        "name": "eap74-amq-s2i"
     },
     "labels": {
-        "template": "eap74-beta-third-party-db-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-amq-s2i",
+        "xpaas": "7.4.0"
     },
-    "message": "A new EAP based application with SSL support has been created in your project. Please be sure to create the following secrets:\"${CONFIGURATION_NAME}\" containing the datasource configuration details required by the deployed application(s);  \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "message": "A new JBoss EAP and AMQ 7 based application with SSL support has been created in your project. The username/password for accessing the AMQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,23 +30,16 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:latest",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:latest",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
-            "required": true
-        },
-        {
-            "displayName": "Configuration Secret Name",
-            "description": "The name of the secret containing configuration properties for the datasources.",
-            "name": "CONFIGURATION_NAME",
-            "value": "eap-app-config",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "required": true
         },
         {
@@ -60,21 +53,21 @@
             "displayName": "Git Repository URL",
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/jboss-openshift/openshift-quickstarts",
+            "value": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
             "required": true
         },
         {
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "1.5",
+            "value": "7.4.x",
             "required": false
         },
         {
             "displayName": "Context Directory",
             "description": "Path within Git project to build; empty for root project directory.",
             "name": "CONTEXT_DIR",
-            "value": "datavirt/hibernate-webapp",
+            "value": "helloworld-mdb",
             "required": false
         }, 
         {
@@ -91,37 +84,37 @@
             "required": false
         },
         {
-            "displayName": "Drivers ImageStreamTag",
-            "description": "ImageStreamTag definition for the image containing the drivers and configuration, e.g. jboss-datavirt63-driver-openshift:1.1",
-            "name": "EXTENSIONS_IMAGE",
-            "value": "jboss-datavirt63-driver-openshift:1.1",
-            "required": true
-        },
-        {
-            "displayName": "Drivers ImageStream Namespace",
-            "description": "Namespace within which the ImageStream definition for the image containing the drivers and configuration is located.",
-            "name": "EXTENSIONS_IMAGE_NAMESPACE",
-            "value": "openshift",
-            "required": true
-        },
-        {
-            "displayName": "Drivers Image Install Directory",
-            "description": "Full path to the directory within the extensions image where the extensions are located (e.g. install.sh, modules/, etc.)",
-            "name": "EXTENSIONS_INSTALL_DIR",
-            "value": "/extensions",
-            "required": true
-        },
-        {
-            "displayName": "Queue Names",
-            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
-            "name": "MQ_QUEUES",
-            "value": "",
+            "displayName": "JMS Connection Factory JNDI Name",
+            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:jboss/DefaultJMSConnectionFactory",
+            "name": "MQ_JNDI",
+            "value": "java:jboss/DefaultJMSConnectionFactory",
             "required": false
         },
         {
-            "displayName": "Topic Names",
+            "displayName": "AMQ Protocols",
+            "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
+            "name": "MQ_PROTOCOL",
+            "value": "openwire",
+            "required": false
+        },
+        {
+            "displayName": "Queues",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
+            "name": "MQ_QUEUES",
+            "value": "HelloWorldMDBQueue",
+            "required": false
+        },
+        {
+            "displayName": "Topics",
             "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
+            "value": "HelloWorldMDBTopic",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Serializable Packages",
+            "description": "List of packages that are allowed to be serialized for use in ObjectMessage, separated by commas. If your app doesn't use ObjectMessages, leave this blank. This is a security enforcement. For the rationale, see http://activemq.apache.org/objectmessage.html",
+            "name": "MQ_SERIALIZABLE_PACKAGES",
             "value": "",
             "required": false
         },
@@ -129,7 +122,7 @@
             "displayName": "Server Keystore Secret Name",
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
-            "value": "eap-app-secret",
+            "value": "eap7-app-secret",
             "required": true
         },
         {
@@ -150,27 +143,55 @@
             "displayName": "Server Certificate Name",
             "description": "The name associated with the server certificate",
             "name": "HTTPS_NAME",
-            "value": "jboss",
+            "value": "",
             "required": false
         },
         {
             "displayName": "Server Keystore Password",
             "description": "The password for the keystore and certificate",
             "name": "HTTPS_PASSWORD",
-            "value": "mykeystorepass",
+            "value": "",
             "required": false
         },
         {
-            "displayName": "Messaging Cluster Admin Password",
-            "description": "Admin password for Messaging cluster.",
-            "name": "MQ_CLUSTER_PASSWORD",
+            "displayName": "AMQ Username",
+            "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+            "name": "MQ_USERNAME",
+            "from": "user[a-zA-Z0-9]{3}",
+            "generate": "expression",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Password",
+            "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
+            "name": "MQ_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
-            "required": true
+            "required": false
+        },
+        {
+            "displayName": "AMQ Role",
+            "description": "AMQ Role for authenticated user",
+            "name": "MQ_ROLE",
+            "value": "admin"
+        },
+        {
+            "displayName": "AMQ Mesh Discovery Type",
+            "description": "The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace.",
+            "name": "AMQ_MESH_DISCOVERY_TYPE",
+            "value": "dns",
+            "required": false
+        },
+        {
+            "displayName": "AMQ Storage Limit",
+            "description": "The AMQ storage usage limit",
+            "name": "AMQ_STORAGE_USAGE_LIMIT",
+            "value": "100 gb",
+            "required": false
         },
         {
             "displayName": "Github Webhook Secret",
-            "description": "A secret string used to configure the GitHub webhook.",
+            "description": "GitHub trigger secret",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -178,7 +199,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "A secret string used to configure the Generic webhook.",
+            "description": "Generic build trigger secret",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -193,35 +214,35 @@
         },
         {
             "displayName": "JGroups Secret Name",
-            "description": "The name of the secret containing the keystore to be used for securing JGroups communications.",
+            "description": "The name of the secret containing the keystore file",
             "name": "JGROUPS_ENCRYPT_SECRET",
-            "value": "eap-app-secret",
+            "value": "eap7-app-secret",
             "required": false
         },
         {
             "displayName": "JGroups Keystore Filename",
-            "description": "The name of the keystore file within the JGroups secret.",
+            "description": "The name of the keystore file within the secret",
             "name": "JGROUPS_ENCRYPT_KEYSTORE",
             "value": "jgroups.jceks",
             "required": false
         },
         {
             "displayName": "JGroups Certificate Name",
-            "description": "The name associated with the JGroups server certificate",
+            "description": "The name associated with the server certificate",
             "name": "JGROUPS_ENCRYPT_NAME",
-            "value": "secret-key",
+            "value": "",
             "required": false
         },
         {
             "displayName": "JGroups Keystore Password",
             "description": "The password for the keystore and certificate",
             "name": "JGROUPS_ENCRYPT_PASSWORD",
-            "value": "password",
+            "value": "",
             "required": false
         },
         {
             "displayName": "JGroups Cluster Password",
-            "description": "Password used by JGroups to authenticate nodes in the cluster.",
+            "description": "JGroups cluster password",
             "name": "JGROUPS_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -245,7 +266,7 @@
             "displayName": "Maven Additional Arguments",
             "description": "Maven additional arguments to use for S2I builds",
             "name": "MAVEN_ARGS_APPEND",
-            "value": "",
+            "value": "-Dcom.redhat.xpaas.repo.jbossorg",
             "required": false
         },
         {
@@ -282,7 +303,8 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's http port."
+                    "description": "The web server's HTTP port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-amq-tcp\", \"kind\": \"Service\"}]"
                 }
             }
         },
@@ -306,7 +328,8 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's https port."
+                    "description": "The web server's HTTPS port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-amq-tcp\", \"kind\": \"Service\"}]"
                 }
             }
         },
@@ -338,6 +361,56 @@
             }
         },
         {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "ports": [
+                    {
+                        "port": 61616,
+                        "targetPort": 61616
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-tcp",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The broker's OpenWire port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "clusterIP": "None",
+                "ports": [
+                    {
+                        "name": "mesh",
+                        "port": 61616
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq-mesh",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+                    "description": "Supports node discovery for mesh formation."
+                }
+            }
+        },
+        {
             "kind": "Route",
             "apiVersion": "v1",
             "id": "${APPLICATION_NAME}-http",
@@ -347,7 +420,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "Route for application's http service."
+                    "description": "Route for application's HTTP service."
                 }
             },
             "spec": {
@@ -366,7 +439,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "Route for application's https service."
+                    "description": "Route for application's HTTPS service."
                 }
             },
             "spec": {
@@ -415,22 +488,7 @@
                         "uri": "${SOURCE_REPOSITORY_URL}",
                         "ref": "${SOURCE_REPOSITORY_REF}"
                     },
-                    "contextDir": "${CONTEXT_DIR}",
-                    "images": [
-                        {
-                            "from": {
-                                "kind": "ImageStreamTag",
-                                "namespace": "${EXTENSIONS_IMAGE_NAMESPACE}",
-                                "name": "${EXTENSIONS_IMAGE}"
-                            },
-                            "paths": [
-                                {
-                                    "destinationDir": "./${CONTEXT_DIR}/extensions/extras",
-                                    "sourcePath": "${EXTENSIONS_INSTALL_DIR}/."
-                                }
-                            ]
-                        }
-                    ]
+                    "contextDir": "${CONTEXT_DIR}"
                 },
                 "strategy": {
                     "type": "Source",
@@ -451,10 +509,6 @@
                             {
                                 "name": "GALLEON_PROVISION_DEFAULT_FAT_SERVER",
                                 "value": "true"
-                            },
-                            {
-                                "name": "CUSTOM_INSTALL_DIRECTORIES",
-                                "value": "extensions/*"
                             },
                             {
                                 "name": "ARTIFACT_DIR",
@@ -492,16 +546,6 @@
                     {
                         "type": "ImageChange",
                         "imageChange": {}
-                    },
-                    {
-                        "type": "ImageChange",
-                        "imageChange": {
-                            "from": {
-                                "kind": "ImageStreamTag",
-                                "namespace": "${EXTENSIONS_IMAGE_NAMESPACE}",
-                                "name": "${EXTENSIONS_IMAGE}"
-                            }
-                        }
                     },
                     {
                         "type": "ConfigChange"
@@ -613,7 +657,7 @@
                         }
                     },
                     "spec": {
-                        "terminationGracePeriodSeconds": 75,
+                        "terminationGracePeriodSeconds": 60,
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}",
@@ -625,11 +669,6 @@
                                     }
                                 },
                                 "volumeMounts": [
-                                    {
-                                        "name": "configuration",
-                                        "mountPath": "/etc/eap-environment",
-                                        "readOnly": true
-                                    },
                                     {
                                         "name": "eap-keystore-volume",
                                         "mountPath": "/etc/eap-secret-volume",
@@ -685,6 +724,42 @@
                                 ],
                                 "env": [
                                     {
+                                        "name": "MQ_SERVICE_PREFIX_MAPPING",
+                                        "value": "${APPLICATION_NAME}-amq7=MQ"
+                                    },
+                                    {
+                                        "name": "MQ_JNDI",
+                                        "value": "${MQ_JNDI}"
+                                    },
+                                    {
+                                        "name": "MQ_USERNAME",
+                                        "value": "${MQ_USERNAME}"
+                                    },
+                                    {
+                                        "name": "MQ_PASSWORD",
+                                        "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_ROLE",
+                                        "value": "${MQ_ROLE}"
+                                    },
+                                    {
+                                        "name": "MQ_PROTOCOL",
+                                        "value": "tcp"
+                                    },
+                                    {
+                                        "name": "MQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "MQ_TOPICS",
+                                        "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "MQ_SERIALIZABLE_PACKAGES",
+                                        "value": "${MQ_SERIALIZABLE_PACKAGES}"
+                                    },
+                                    {
                                         "name": "JGROUPS_PING_PROTOCOL",
                                         "value": "dns.DNS_PING"
                                     },
@@ -695,10 +770,6 @@
                                     {
                                         "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
                                         "value": "8888"
-                                    },
-                                    {
-                                        "name": "ENV_FILES",
-                                        "value": "/etc/eap-environment/*"
                                     },
                                     {
                                         "name": "HTTPS_KEYSTORE_DIR",
@@ -719,18 +790,6 @@
                                     {
                                         "name": "HTTPS_PASSWORD",
                                         "value": "${HTTPS_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "MQ_CLUSTER_PASSWORD",
-                                        "value": "${MQ_CLUSTER_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "MQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "MQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "JGROUPS_ENCRYPT_SECRET",
@@ -769,12 +828,6 @@
                         ],
                         "volumes": [
                             {
-                                "name": "configuration",
-                                "secret": {
-                                    "secretName": "${CONFIGURATION_NAME}"
-                                }
-                            },
-                            {
                                 "name": "eap-keystore-volume",
                                 "secret": {
                                     "secretName": "${HTTPS_SECRET}"
@@ -785,6 +838,160 @@
                                 "secret": {
                                     "secretName": "${JGROUPS_ENCRYPT_SECRET}"
                                 }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-amq",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "${APPLICATION_NAME}-amq"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                                "name": "amq-broker-72-openshift:1.1"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}-amq"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}-amq",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}-amq",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}-amq",
+                                "image": "amq-broker-72-openshift",
+                                "imagePullPolicy": "Always",
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/amq/bin/readinessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "ports": [
+                                    {
+                                        "name": "console-jolokia",
+                                        "containerPort": 8161,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "amqp",
+                                        "containerPort": 5672,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "amqp-ssl",
+                                        "containerPort": 5671,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "mqtt",
+                                        "containerPort": 1883,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "stomp",
+                                        "containerPort": 61613,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "stomp-ssl",
+                                        "containerPort": 61612,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "tcp",
+                                        "containerPort": 61616,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "tcp-ssl",
+                                        "containerPort": 61617,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "AMQ_USER",
+                                        "value": "${MQ_USERNAME}"
+                                    },
+                                    {
+                                        "name": "AMQ_PASSWORD",
+                                        "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AMQ_TRANSPORTS",
+                                        "value": "${MQ_PROTOCOL}"
+                                    },
+                                    {
+                                        "name": "AMQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "AMQ_ADDRESSES",
+                                        "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "MQ_SERIALIZABLE_PACKAGES",
+                                        "value": "${MQ_SERIALIZABLE_PACKAGES}"
+                                    },
+                                    {
+                                        "name": "AMQ_MESH_DISCOVERY_TYPE",
+                                        "value": "${AMQ_MESH_DISCOVERY_TYPE}"
+                                    },
+                                    {
+                                        "name": "AMQ_MESH_SERVICE_NAME",
+                                        "value": "${APPLICATION_NAME}-amq-mesh"
+                                    },
+                                    {
+                                        "name": "AMQ_MESH_SERVICE_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "AMQ_STORAGE_USAGE_LIMIT",
+                                        "value": "${AMQ_STORAGE_USAGE_LIMIT}"
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/templates/eap74-basic-s2i.json
+++ b/templates/eap74-basic-s2i.json
@@ -5,19 +5,19 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta Starter",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc",
+            "description": "An example JBoss Enterprise Application Platform application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc",
             "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration and secure communication using edge TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-starter-s2i"
+        "name": "eap74-basic-s2i"
     },
     "labels": {
-        "template": "eap74-beta-starter-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-basic-s2i",
+        "xpaas": "7.4.0"
     },
     "message": "A new JBoss EAP based application has been created in your project.",
     "parameters": [
@@ -30,16 +30,16 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:latest",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:latest",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "required": true
         },
         {
@@ -77,6 +77,28 @@
             "required": false
         },
         {
+            "displayName": "Queues",
+            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
+            "name": "MQ_QUEUES",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Topics",
+            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
+            "name": "MQ_TOPICS",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
+            "name": "MQ_CLUSTER_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        },
+        {
             "displayName": "Github Webhook Secret",
             "description": "GitHub trigger secret",
             "name": "GITHUB_WEBHOOK_SECRET",
@@ -97,6 +119,14 @@
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
             "name": "IMAGE_STREAM_NAMESPACE",
             "value": "openshift",
+            "required": true
+        },
+        {
+            "displayName": "JGroups Cluster Password",
+            "description": "JGroups cluster password",
+            "name": "JGROUPS_CLUSTER_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
             "required": true
         },
         {
@@ -155,6 +185,33 @@
                 },
                 "annotations": {
                     "description": "The web server's http port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "publishNotReadyAddresses": true,
+                "clusterIP": "None",
+                "ports": [
+                    {
+                        "name": "ping",
+                        "port": 8888
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-ping",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+                    "description": "The JGroups ping port for clustering."
                 }
             }
         },
@@ -427,9 +484,42 @@
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "ping",
+                                        "containerPort": 8888,
+                                        "protocol": "TCP"
                                     }
                                 ],
                                 "env": [
+                                    {
+                                        "name": "JGROUPS_PING_PROTOCOL",
+                                        "value": "dns.DNS_PING"
+                                    },
+                                    {
+                                        "name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+                                        "value": "${APPLICATION_NAME}-ping"
+                                    },
+                                    {
+                                        "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+                                        "value": "8888"
+                                    },
+                                    {
+                                        "name": "MQ_CLUSTER_PASSWORD",
+                                        "value": "${MQ_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "MQ_TOPICS",
+                                        "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_CLUSTER_PASSWORD",
+                                        "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
                                     {
                                         "name": "AUTO_DEPLOY_EXPLODED",
                                         "value": "${AUTO_DEPLOY_EXPLODED}"

--- a/templates/eap74-https-s2i.json
+++ b/templates/eap74-https-s2i.json
@@ -5,21 +5,21 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0 with passthrough TLS",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc",
-            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration and secure communication using edge TLS.",
+            "description": "An example JBoss Enterprise Application Platform application configured with secure communication using HTTPS. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc",
+            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform application, including a build configuration, application deployment configuration and secure communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-basic-s2i"
+        "name": "eap74-https-s2i"
     },
     "labels": {
-        "template": "eap74-beta-basic-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-https-s2i",
+        "xpaas": "7.4.0"
     },
-    "message": "A new JBoss EAP based application has been created in your project.",
+    "message": "A new JBoss EAP based application with SSL support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,17 +30,24 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:latest",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:latest",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "required": true
+        },
+        {
+            "displayName": "Custom https Route Hostname",
+            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix>",
+            "name": "HOSTNAME_HTTPS",
+            "value": "",
+            "required": false
         },
         {
             "displayName": "Git Repository URL",
@@ -91,6 +98,41 @@
             "required": false
         },
         {
+            "displayName": "Server Keystore Secret Name",
+            "description": "The name of the secret containing the keystore file",
+            "name": "HTTPS_SECRET",
+            "value": "eap7-app-secret",
+            "required": true
+        },
+        {
+            "displayName": "Server Keystore Filename",
+            "description": "The name of the keystore file within the secret",
+            "name": "HTTPS_KEYSTORE",
+            "value": "keystore.jks",
+            "required": false
+        },
+        {
+            "displayName": "Server Keystore Type",
+            "description": "The type of the keystore file (JKS or JCEKS)",
+            "name": "HTTPS_KEYSTORE_TYPE",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Server Certificate Name",
+            "description": "The name associated with the server certificate",
+            "name": "HTTPS_NAME",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Server Keystore Password",
+            "description": "The password for the keystore and certificate",
+            "name": "HTTPS_PASSWORD",
+            "value": "",
+            "required": false
+        },
+        {
             "displayName": "AMQ cluster password",
             "description": "AMQ cluster admin password",
             "name": "MQ_CLUSTER_PASSWORD",
@@ -120,6 +162,34 @@
             "name": "IMAGE_STREAM_NAMESPACE",
             "value": "openshift",
             "required": true
+        },
+        {
+            "displayName": "JGroups Secret Name",
+            "description": "The name of the secret containing the keystore file",
+            "name": "JGROUPS_ENCRYPT_SECRET",
+            "value": "eap7-app-secret",
+            "required": false
+        },
+        {
+            "displayName": "JGroups Keystore Filename",
+            "description": "The name of the keystore file within the secret",
+            "name": "JGROUPS_ENCRYPT_KEYSTORE",
+            "value": "jgroups.jceks",
+            "required": false
+        },
+        {
+            "displayName": "JGroups Certificate Name",
+            "description": "The name associated with the server certificate",
+            "name": "JGROUPS_ENCRYPT_NAME",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "JGroups Keystore Password",
+            "description": "The password for the keystore and certificate",
+            "name": "JGROUPS_ENCRYPT_PASSWORD",
+            "value": "",
+            "required": false
         },
         {
             "displayName": "JGroups Cluster Password",
@@ -192,6 +262,30 @@
             "kind": "Service",
             "apiVersion": "v1",
             "spec": {
+                "ports": [
+                    {
+                        "port": 8443,
+                        "targetPort": 8443
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            },
+            "metadata": {
+                "name": "secure-${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "The web server's https port."
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
                 "publishNotReadyAddresses": true,
                 "clusterIP": "None",
                 "ports": [
@@ -218,9 +312,28 @@
         {
             "kind": "Route",
             "apiVersion": "v1",
-            "id": "${APPLICATION_NAME}-https",
+            "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for application's http service."
+                }
+            },
+            "spec": {
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-https",
+            "metadata": {
+                "name": "secure-${APPLICATION_NAME}",
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },
@@ -229,12 +342,12 @@
                 }
             },
             "spec": {
+                "host": "${HOSTNAME_HTTPS}",
                 "to": {
-                    "name": "${APPLICATION_NAME}"
+                    "name": "secure-${APPLICATION_NAME}"
                 },
                 "tls": {
-                    "insecureEdgeTerminationPolicy": "Redirect",
-                    "termination": "edge"
+                    "termination": "passthrough"
                 }
             }
         },
@@ -454,6 +567,18 @@
                                         "memory": "${MEMORY_LIMIT}"
                                     }
                                 },
+                                "volumeMounts": [
+                                    {
+                                        "name": "eap-keystore-volume",
+                                        "mountPath": "/etc/eap-secret-volume",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "name": "eap-jgroups-keystore-volume",
+                                        "mountPath": "/etc/jgroups-encrypt-secret-volume",
+                                        "readOnly": true
+                                    }
+                                ],
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [
@@ -486,6 +611,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "https",
+                                        "containerPort": 8443,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "ping",
                                         "containerPort": 8888,
                                         "protocol": "TCP"
@@ -505,6 +635,26 @@
                                         "value": "8888"
                                     },
                                     {
+                                        "name": "HTTPS_KEYSTORE_DIR",
+                                        "value": "/etc/eap-secret-volume"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE",
+                                        "value": "${HTTPS_KEYSTORE}"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE_TYPE",
+                                        "value": "${HTTPS_KEYSTORE_TYPE}"
+                                    },
+                                    {
+                                        "name": "HTTPS_NAME",
+                                        "value": "${HTTPS_NAME}"
+                                    },
+                                    {
+                                        "name": "HTTPS_PASSWORD",
+                                        "value": "${HTTPS_PASSWORD}"
+                                    },
+                                    {
                                         "name": "MQ_CLUSTER_PASSWORD",
                                         "value": "${MQ_CLUSTER_PASSWORD}"
                                     },
@@ -515,6 +665,26 @@
                                     {
                                         "name": "MQ_TOPICS",
                                         "value": "${MQ_TOPICS}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_SECRET",
+                                        "value": "${JGROUPS_ENCRYPT_SECRET}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
+                                        "value": "/etc/jgroups-encrypt-secret-volume"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_KEYSTORE",
+                                        "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_NAME",
+                                        "value": "${JGROUPS_ENCRYPT_NAME}"
+                                    },
+                                    {
+                                        "name": "JGROUPS_ENCRYPT_PASSWORD",
+                                        "value": "${JGROUPS_ENCRYPT_PASSWORD}"
                                     },
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
@@ -529,6 +699,20 @@
                                         "value": "${ENABLE_GENERATE_DEFAULT_DATASOURCE}"
                                     }
                                 ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "eap-keystore-volume",
+                                "secret": {
+                                    "secretName": "${HTTPS_SECRET}"
+                                }
+                            },
+                            {
+                                "name": "eap-jgroups-keystore-volume",
+                                "secret": {
+                                    "secretName": "${JGROUPS_ENCRYPT_SECRET}"
+                                }
                             }
                         ]
                     }

--- a/templates/eap74-sso-s2i.json
+++ b/templates/eap74-sso-s2i.json
@@ -4,22 +4,22 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
-            "tags": "eap,javaee,java,jboss",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta + AMQ 7 with passthrough TLS",
+            "tags": "eap,javaee,java,jboss,hidden",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0 + Single Sign-On with passthrough TLS",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application using Red Hat JBoss AMQ with persistence and secure communication using https. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc",
-            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration, using Red Hat JBoss AMQ with persistence and secure communication using passthrough TLS.",
+            "description": "An example JBoss Enterprise Application Platform application Single Sign-On application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc",
+            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration, integrated with Red Hat Single Sign-On and secure communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-amq-persistent-s2i"
+        "name": "eap74-sso-s2i"
     },
     "labels": {
-        "template": "eap74-beta-amq-persistent-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-sso-s2i",
+        "xpaas": "7.4.0"
     },
-    "message": "A new JBoss EAP and AMQ persistent based application with SSL support has been created in your project. The username/password for accessing the AMQ service is ${MQ_USERNAME}/${MQ_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "message": "A new JBoss EAP application with SSL and SSO support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,46 +30,53 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:latest",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:latest",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
+            "required": true
+        },
+        {
+            "displayName": "SSO Image Name",
+            "description": "Name of the SSO image to use, examples: redhat-sso74-openshift:latest",
+            "name": "SSO_IMAGE_NAME",
+            "value": "redhat-sso74-openshift:latest",
             "required": true
         },
         {
             "displayName": "Custom https Route Hostname",
-            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix>",
+            "description": "Hostname for https service route (e.g. secure-eap-app-myproject.example.com).  Required for SSO-enabled applications.  This is added to the white list of redirects in the SSO server.",
             "name": "HOSTNAME_HTTPS",
             "value": "",
-            "required": false
+            "required": true
         },
         {
             "displayName": "Git Repository URL",
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/jboss-developer/jboss-eap-quickstarts.git",
+            "value": "https://github.com/redhat-developer/redhat-sso-quickstarts",
             "required": true
         },
         {
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "7.4.x",
+            "value": "7.0.x-ose",
             "required": false
         },
         {
             "displayName": "Context Directory",
             "description": "Path within Git project to build; empty for root project directory.",
             "name": "CONTEXT_DIR",
-            "value": "helloworld-mdb",
+            "value": "",
             "required": false
-        }, 
+        },
         {
             "displayName": "Galleon layers",
             "description": "Comma separated list of Galleon layers to provision a server.",
@@ -84,60 +91,33 @@
             "required": false
         },
         {
-            "displayName": "AMQ Volume Size",
-            "description": "Size of the volume used by AMQ for persisting messages.",
-            "name": "VOLUME_CAPACITY",
-            "value": "1Gi",
-            "required": true
-        },
-        {
-            "displayName": "JMS Connection Factory JNDI Name",
-            "description": "JNDI name for connection factory used by applications to connect to the broker, e.g. java:jboss/DefaultJMSConnectionFactory",
-            "name": "MQ_JNDI",
-            "value": "java:jboss/DefaultJMSConnectionFactory",
-            "required": false
-        },
-        {
-            "displayName": "Split the data directory?",
-            "description": "Split the data directory for each node in a mesh.",
-            "name": "AMQ_SPLIT",
-            "value": "false",
-            "required": false
-        },
-        {
-            "displayName": "AMQ Protocols",
-            "description": "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP.",
-            "name": "MQ_PROTOCOL",
-            "value": "openwire",
-            "required": false
-        },
-        {
             "displayName": "Queues",
             "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
-            "value": "HelloWorldMDBQueue",
+            "value": "",
             "required": false
         },
         {
             "displayName": "Topics",
             "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
-            "value": "HelloWorldMDBTopic",
+            "value": "",
             "required": false
         },
         {
-            "displayName": "AMQ Serializable Packages",
-            "description": "List of packages that are allowed to be serialized for use in ObjectMessage, separated by commas. If your app doesn't use ObjectMessages, leave this blank. This is a security enforcement. For the rationale, see http://activemq.apache.org/objectmessage.html",
-            "name": "MQ_SERIALIZABLE_PACKAGES",
-            "value": "",
-            "required": false
+            "displayName": "AMQ cluster password",
+            "description": "AMQ cluster admin password",
+            "name": "MQ_CLUSTER_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
         },
         {
             "displayName": "Server Keystore Secret Name",
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
             "value": "eap7-app-secret",
-            "required": false
+            "required": true
         },
         {
             "displayName": "Server Keystore Filename",
@@ -155,52 +135,16 @@
         },
         {
             "displayName": "Server Certificate Name",
-            "description": "The name associated with the server certificate",
+            "description": "The name associated with the server certificate (e.g. jboss)",
             "name": "HTTPS_NAME",
             "value": "",
             "required": false
         },
         {
             "displayName": "Server Keystore Password",
-            "description": "The password for the keystore and certificate",
+            "description": "The password for the keystore and certificate (e.g. mykeystorepass)",
             "name": "HTTPS_PASSWORD",
             "value": "",
-            "required": false
-        },
-        {
-            "displayName": "AMQ Username",
-            "description": "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
-            "name": "MQ_USERNAME",
-            "from": "user[a-zA-Z0-9]{3}",
-            "generate": "expression",
-            "required": false
-        },
-        {
-            "displayName": "AMQ Password",
-            "description": "Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.",
-            "name": "MQ_PASSWORD",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
-            "required": false
-        },
-        {
-            "displayName": "AMQ Role",
-            "description": "AMQ Role for authenticated user",
-            "name": "MQ_ROLE",
-            "value": "admin"
-        },
-        {
-            "displayName": "AMQ Mesh Discovery Type",
-            "description": "The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace.",
-            "name": "AMQ_MESH_DISCOVERY_TYPE",
-            "value": "dns",
-            "required": false
-        },
-        {
-            "displayName": "AMQ Storage Limit",
-            "description": "The AMQ storage usage limit",
-            "name": "AMQ_STORAGE_USAGE_LIMIT",
-            "value": "100 gb",
             "required": false
         },
         {
@@ -242,14 +186,14 @@
         },
         {
             "displayName": "JGroups Certificate Name",
-            "description": "The name associated with the server certificate",
+            "description": "The name associated with the server certificate (e.g. secret-key)",
             "name": "JGROUPS_ENCRYPT_NAME",
             "value": "",
             "required": false
         },
         {
             "displayName": "JGroups Keystore Password",
-            "description": "The password for the keystore and certificate",
+            "description": "The password for the keystore and certificate (e.g. password)",
             "name": "JGROUPS_ENCRYPT_PASSWORD",
             "value": "",
             "required": false
@@ -270,6 +214,140 @@
             "required": false
         },
         {
+            "displayName": "URL for SSO",
+            "description": "The URL for the SSO server (e.g. https://secure-sso-myproject.example.com/auth).  This is the URL through which the user will be redirected when a login or token is required by the application.",
+            "name": "SSO_URL",
+            "value": "",
+            "required": true
+        },
+        {
+            "displayName": "URL for SSO (internal service)",
+            "description": "The URL for the internal SSO service, where secure-sso (the default) is the kubernetes service exposed by the SSO server.  This is used to create the application client(s) (see SSO_USERNAME).  This can also be the same as SSO_URL.",
+            "name": "SSO_SERVICE_URL",
+            "value": "https://secure-sso:8443/auth",
+            "required": false
+        },
+        {
+            "displayName": "SSO Realm",
+            "description": "The SSO realm to which the application client(s) should be associated (e.g. demo).",
+            "name": "SSO_REALM",
+            "value": "",
+            "required": true
+        },
+        {
+            "displayName": "SSO Username",
+            "description": "The username used to access the SSO service.  This is used to create the appliction client(s) within the specified SSO realm. This should match the SSO_SERVICE_USERNAME specified through one of the sso70-* templates.",
+            "name": "SSO_USERNAME",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "SSO Password",
+            "description": "The password for the SSO service user.",
+            "name": "SSO_PASSWORD",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "SSO Public Key",
+            "description": "SSO Public Key. Public key is recommended to be passed into the template to avoid man-in-the-middle security vulnerability",
+            "name": "SSO_PUBLIC_KEY",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "SSO Bearer Only?",
+            "description": "SSO Client Access Type",
+            "name": "SSO_BEARER_ONLY",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "Artifact Directories",
+            "description": "List of directories from which archives will be copied into the deployment folder.  If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
+            "value": "app-jee-jsp/target,service-jee-jaxrs/target,app-profile-jee-jsp/target,app-profile-saml-jee-jsp/target",
+            "required": false
+        },
+        {
+            "displayName": "SSO SAML Keystore Secret",
+            "description": "The name of the secret containing the keystore file",
+            "name": "SSO_SAML_KEYSTORE_SECRET",
+            "value": "eap7-app-secret",
+            "required": false
+        },
+        {
+            "displayName": "SSO SAML Keystore",
+            "description": "The name of the keystore file within the secret",
+            "name": "SSO_SAML_KEYSTORE",
+            "value": "keystore.jks",
+            "required": false
+        },
+        {
+            "displayName": "SSO SAML Certificate Name",
+            "description": "The name associated with the server certificate",
+            "name": "SSO_SAML_CERTIFICATE_NAME",
+            "value": "jboss",
+            "required": false
+        },
+        {
+            "displayName": "SSO SAML Keystore Password",
+            "description": "The password for the keystore and certificate",
+            "name": "SSO_SAML_KEYSTORE_PASSWORD",
+            "value": "mykeystorepass",
+            "required": false
+        },
+        {
+            "displayName": "SSO Client Secret",
+            "description": "The SSO Client Secret for Confidential Access",
+            "name": "SSO_SECRET",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        },
+        {
+            "displayName": "Enable CORS for SSO?",
+            "description": "Enable CORS for SSO applications",
+            "name": "SSO_ENABLE_CORS",
+            "value": "false",
+            "required": false
+        },
+        {
+            "displayName": "SSO SAML Logout Page",
+            "description": "SSO logout page for SAML applications",
+            "name": "SSO_SAML_LOGOUT_PAGE",
+            "value": "/",
+            "required": false
+        },
+        {
+            "displayName": "Disable SSL Validation in EAP->SSO communication",
+            "description": "If true SSL communication between EAP and the SSO Server will be insecure (i.e. certificate validation is disabled with curl)",
+            "name": "SSO_DISABLE_SSL_CERTIFICATE_VALIDATION",
+            "value": "true",
+            "required": false
+        },
+        {
+            "displayName": "SSO Trust Store",
+            "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
+            "name": "SSO_TRUSTSTORE",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "SSO Trust Store Password",
+            "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
+            "name": "SSO_TRUSTSTORE_PASSWORD",
+            "value": "",
+            "required": false
+        },
+        {
+            "displayName": "SSO Trust Store Secret",
+            "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
+            "name": "SSO_TRUSTSTORE_SECRET",
+            "value": "eap7-app-secret",
+            "required": false
+        },
+        {
             "displayName": "Maven mirror URL",
             "description": "Maven mirror to use for S2I builds",
             "name": "MAVEN_MIRROR_URL",
@@ -280,12 +358,6 @@
             "displayName": "Maven Additional Arguments",
             "description": "Maven additional arguments to use for S2I builds",
             "name": "MAVEN_ARGS_APPEND",
-            "value": "-Dcom.redhat.xpaas.repo.jbossorg",            
-            "required": false
-        },
-        {
-            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
-            "name": "ARTIFACT_DIR",
             "value": "",
             "required": false
         },
@@ -317,8 +389,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's HTTP port.",
-                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-amq-tcp\", \"kind\": \"Service\"}]"
+                    "description": "The web server's http port."
                 }
             }
         },
@@ -342,8 +413,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's HTTPS port.",
-                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-amq-tcp\", \"kind\": \"Service\"}]"
+                    "description": "The web server's https port."
                 }
             }
         },
@@ -375,56 +445,6 @@
             }
         },
         {
-            "kind": "Service",
-            "apiVersion": "v1",
-            "spec": {
-                "ports": [
-                    {
-                        "port": 61616,
-                        "targetPort": 61616
-                    }
-                ],
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-amq"
-                }
-            },
-            "metadata": {
-                "name": "${APPLICATION_NAME}-amq-tcp",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "annotations": {
-                    "description": "The broker's OpenWire port."
-                }
-            }
-        },
-        {
-            "kind": "Service",
-            "apiVersion": "v1",
-            "spec": {
-                "clusterIP": "None",
-                "ports": [
-                    {
-                        "name": "mesh",
-                        "port": 61616
-                    }
-                ],
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-amq"
-                }
-            },
-            "metadata": {
-                "name": "${APPLICATION_NAME}-amq-mesh",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-                    "description": "Supports node discovery for mesh formation."
-                }
-            }
-        },
-        {
             "kind": "Route",
             "apiVersion": "v1",
             "id": "${APPLICATION_NAME}-http",
@@ -434,7 +454,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "Route for application's HTTP service."
+                    "description": "Route for application's http service."
                 }
             },
             "spec": {
@@ -453,7 +473,7 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "Route for application's HTTPS service."
+                    "description": "Route for application's https service."
                 }
             },
             "spec": {
@@ -502,12 +522,42 @@
                         "uri": "${SOURCE_REPOSITORY_URL}",
                         "ref": "${SOURCE_REPOSITORY_REF}"
                     },
-                    "contextDir": "${CONTEXT_DIR}"
+                    "contextDir": "${CONTEXT_DIR}",
+                    "images": [
+                        {
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                                "name": "${SSO_IMAGE_NAME}"
+                            },
+                            "paths": [
+                                {
+                                    "destinationDir": "./${CONTEXT_DIR}/extensions/sso-adapters",
+                                    "sourcePath": "/opt/rh/rh-sso/client/eap7/."
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "strategy": {
                     "type": "Source",
                     "sourceStrategy": {
+                        "forcePull": true,
+                        "incremental": true,
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                            "name": "${EAP_IMAGE_NAME}"
+                        },
                         "env": [
+                            {
+                                "name": "CUSTOM_INSTALL_DIRECTORIES",
+                                "value": "extensions/*"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
+                            },
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
@@ -523,19 +573,8 @@
                             {
                                 "name": "GALLEON_PROVISION_DEFAULT_FAT_SERVER",
                                 "value": "true"
-                            },
-                            {
-                                "name": "ARTIFACT_DIR",
-                                "value": "${ARTIFACT_DIR}"
                             }
-                        ],
-                        "forcePull": true,
-                        "incremental": true,
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "${EAP_IMAGE_NAME}"
-                        }
+                        ]
                     }
                 },
                 "output": {
@@ -671,7 +710,7 @@
                         }
                     },
                     "spec": {
-                        "terminationGracePeriodSeconds": 60,
+                        "terminationGracePeriodSeconds": 75,
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}",
@@ -684,6 +723,11 @@
                                 },
                                 "volumeMounts": [
                                     {
+                                        "name": "sso-saml-keystore-volume",
+                                        "mountPath": "/etc/sso-saml-secret-volume",
+                                        "readOnly": true
+                                    },
+                                    {
                                         "name": "eap-keystore-volume",
                                         "mountPath": "/etc/eap-secret-volume",
                                         "readOnly": true
@@ -691,6 +735,11 @@
                                     {
                                         "name": "eap-jgroups-keystore-volume",
                                         "mountPath": "/etc/jgroups-encrypt-secret-volume",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "name": "sso-truststore-volume",
+                                        "mountPath": "/etc/sso-secret-volume",
                                         "readOnly": true
                                     }
                                 ],
@@ -738,38 +787,6 @@
                                 ],
                                 "env": [
                                     {
-                                        "name": "MQ_SERVICE_PREFIX_MAPPING",
-                                        "value": "${APPLICATION_NAME}-amq7=MQ"
-                                    },
-                                    {
-                                        "name": "MQ_JNDI",
-                                        "value": "${MQ_JNDI}"
-                                    },
-                                    {
-                                        "name": "MQ_USERNAME",
-                                        "value": "${MQ_USERNAME}"
-                                    },
-                                    {
-                                        "name": "MQ_PASSWORD",
-                                        "value": "${MQ_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "MQ_PROTOCOL",
-                                        "value": "tcp"
-                                    },
-                                    {
-                                        "name": "MQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "MQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
-                                    },
-                                    {
-                                        "name": "MQ_SERIALIZABLE_PACKAGES",
-                                        "value": "${MQ_SERIALIZABLE_PACKAGES}"
-                                    },
-                                    {
                                         "name": "JGROUPS_PING_PROTOCOL",
                                         "value": "dns.DNS_PING"
                                     },
@@ -780,6 +797,14 @@
                                     {
                                         "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
                                         "value": "8888"
+                                    },
+                                    {
+                                        "name": "HOSTNAME_HTTP",
+                                        "value": "${HOSTNAME_HTTP}"
+                                    },
+                                    {
+                                        "name": "HOSTNAME_HTTPS",
+                                        "value": "${HOSTNAME_HTTPS}"
                                     },
                                     {
                                         "name": "HTTPS_KEYSTORE_DIR",
@@ -800,6 +825,18 @@
                                     {
                                         "name": "HTTPS_PASSWORD",
                                         "value": "${HTTPS_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_CLUSTER_PASSWORD",
+                                        "value": "${MQ_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_QUEUES",
+                                        "value": "${MQ_QUEUES}"
+                                    },
+                                    {
+                                        "name": "MQ_TOPICS",
+                                        "value": "${MQ_TOPICS}"
                                     },
                                     {
                                         "name": "JGROUPS_ENCRYPT_SECRET",
@@ -830,6 +867,82 @@
                                         "value": "${AUTO_DEPLOY_EXPLODED}"
                                     },
                                     {
+                                        "name": "SSO_URL",
+                                        "value": "${SSO_URL}"
+                                    },
+                                    {
+                                        "name": "SSO_SERVICE_URL",
+                                        "value": "${SSO_SERVICE_URL}"
+                                    },
+                                    {
+                                        "name": "SSO_REALM",
+                                        "value": "${SSO_REALM}"
+                                    },
+                                    {
+                                        "name": "SSO_USERNAME",
+                                        "value": "${SSO_USERNAME}"
+                                    },
+                                    {
+                                        "name": "SSO_PASSWORD",
+                                        "value": "${SSO_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "SSO_PUBLIC_KEY",
+                                        "value": "${SSO_PUBLIC_KEY}"
+                                    },
+                                    {
+                                        "name": "SSO_BEARER_ONLY",
+                                        "value": "${SSO_BEARER_ONLY}"
+                                    },
+                                    {
+                                        "name": "SSO_SAML_KEYSTORE_SECRET",
+                                        "value": "${SSO_SAML_KEYSTORE_SECRET}"
+                                    },
+                                    {
+                                        "name": "SSO_SAML_KEYSTORE",
+                                        "value": "${SSO_SAML_KEYSTORE}"
+                                    },
+                                    {
+                                        "name": "SSO_SAML_KEYSTORE_DIR",
+                                        "value": "/etc/sso-saml-secret-volume"
+                                    },
+                                    {
+                                        "name": "SSO_SAML_CERTIFICATE_NAME",
+                                        "value": "${SSO_SAML_CERTIFICATE_NAME}"
+                                    },
+                                    {
+                                        "name": "SSO_SAML_KEYSTORE_PASSWORD",
+                                        "value": "${SSO_SAML_KEYSTORE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "SSO_SECRET",
+                                        "value": "${SSO_SECRET}"
+                                    },
+                                    {
+                                        "name": "SSO_ENABLE_CORS",
+                                        "value": "${SSO_ENABLE_CORS}"
+                                    },
+                                    {
+                                        "name": "SSO_SAML_LOGOUT_PAGE",
+                                        "value": "${SSO_SAML_LOGOUT_PAGE}"
+                                    },
+                                    {
+                                        "name": "SSO_DISABLE_SSL_CERTIFICATE_VALIDATION",
+                                        "value": "${SSO_DISABLE_SSL_CERTIFICATE_VALIDATION}"
+                                    },
+                                    {
+                                        "name": "SSO_TRUSTSTORE",
+                                        "value": "${SSO_TRUSTSTORE}"
+                                    },
+                                    {
+                                        "name": "SSO_TRUSTSTORE_DIR",
+                                        "value": "/etc/sso-secret-volume"
+                                    },
+                                    {
+                                        "name": "SSO_TRUSTSTORE_PASSWORD",
+                                        "value": "${SSO_TRUSTSTORE_PASSWORD}"
+                                    },
+                                    {
                                         "name": "ENABLE_GENERATE_DEFAULT_DATASOURCE",
                                         "value": "${ENABLE_GENERATE_DEFAULT_DATASOURCE}"
                                     }
@@ -837,6 +950,12 @@
                             }
                         ],
                         "volumes": [
+                            {
+                                "name": "sso-saml-keystore-volume",
+                                "secret": {
+                                    "secretName": "${SSO_SAML_KEYSTORE_SECRET}"
+                                }
+                            },
                             {
                                 "name": "eap-keystore-volume",
                                 "secret": {
@@ -848,207 +967,14 @@
                                 "secret": {
                                     "secretName": "${JGROUPS_ENCRYPT_SECRET}"
                                 }
-                            }
-                        ]
-                    }
-                }
-            }
-        },
-        {
-            "kind": "DeploymentConfig",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${APPLICATION_NAME}-amq",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                }
-            },
-            "spec": {
-                "strategy": {
-                    "type": "Rolling",
-                    "rollingParams": {
-                        "maxSurge": 0
-                    }
-                },
-                "triggers": [
-                    {
-                        "type": "ImageChange",
-                        "imageChangeParams": {
-                            "automatic": true,
-                            "containerNames": [
-                                "${APPLICATION_NAME}-amq"
-                            ],
-                            "from": {
-                                "kind": "ImageStreamTag",
-                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "amq-broker-72-openshift:1.1"
-                            }
-                        }
-                    },
-                    {
-                        "type": "ConfigChange"
-                    }
-                ],
-                "replicas": 1,
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}-amq"
-                },
-                "template": {
-                    "metadata": {
-                        "name": "${APPLICATION_NAME}-amq",
-                        "labels": {
-                            "deploymentConfig": "${APPLICATION_NAME}-amq",
-                            "application": "${APPLICATION_NAME}"
-                        }
-                    },
-                    "spec": {
-                        "terminationGracePeriodSeconds": 60,
-                        "containers": [
+                            },
                             {
-                                "name": "${APPLICATION_NAME}-amq",
-                                "image": "amq-broker-72-openshift",
-                                "imagePullPolicy": "Always",
-                                "readinessProbe": {
-                                    "exec": {
-                                        "command": [
-                                            "/bin/bash",
-                                            "-c",
-                                            "/opt/amq/bin/readinessProbe.sh"
-                                        ]
-                                    }
-                                },
-                                "ports": [
-                                    {
-                                        "name": "console-jolokia",
-                                        "containerPort": 8161,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "amqp",
-                                        "containerPort": 5672,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "amqp-ssl",
-                                        "containerPort": 5671,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "mqtt",
-                                        "containerPort": 1883,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "stomp",
-                                        "containerPort": 61613,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "stomp-ssl",
-                                        "containerPort": 61612,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "tcp",
-                                        "containerPort": 61616,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "tcp-ssl",
-                                        "containerPort": 61617,
-                                        "protocol": "TCP"
-                                    }
-                                ],
-                                "volumeMounts": [
-                                    {
-                                        "mountPath": "/opt/amq/data/kahadb",
-                                        "name": "${APPLICATION_NAME}-amq-pvol"
-                                    }
-                                ],
-                                "env": [
-                                    {
-                                        "name": "AMQ_USER",
-                                        "value": "${MQ_USERNAME}"
-                                    },
-                                    {
-                                        "name": "AMQ_PASSWORD",
-                                        "value": "${MQ_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "AMQ_ROLE",
-                                        "value": "${MQ_ROLE}"
-                                    },
-                                    {
-                                        "name": "AMQ_TRANSPORTS",
-                                        "value": "${MQ_PROTOCOL}"
-                                    },
-                                    {
-                                        "name": "AMQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "AMQ_ADDRESSES",
-                                        "value": "${MQ_TOPICS}"
-                                    },
-                                    {
-                                        "name": "MQ_SERIALIZABLE_PACKAGES",
-                                        "value": "${MQ_SERIALIZABLE_PACKAGES}"
-                                    },
-                                    {
-                                        "name": "AMQ_SPLIT",
-                                        "value": "${AMQ_SPLIT}"
-                                    },
-                                    {
-                                        "name": "AMQ_MESH_DISCOVERY_TYPE",
-                                        "value": "${AMQ_MESH_DISCOVERY_TYPE}"
-                                    },
-                                    {
-                                        "name": "AMQ_MESH_SERVICE_NAME",
-                                        "value": "${APPLICATION_NAME}-amq-mesh"
-                                    },
-                                    {
-                                        "name": "AMQ_MESH_SERVICE_NAMESPACE",
-                                        "valueFrom": {
-                                            "fieldRef": {
-                                                "fieldPath": "metadata.namespace"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "name": "AMQ_STORAGE_USAGE_LIMIT",
-                                        "value": "${AMQ_STORAGE_USAGE_LIMIT}"
-                                    }
-                                ]
-                            }
-                        ],
-                        "volumes": [
-                            {
-                                "name": "${APPLICATION_NAME}-amq-pvol",
-                                "persistentVolumeClaim": {
-                                    "claimName": "${APPLICATION_NAME}-amq-claim"
+                                "name": "sso-truststore-volume",
+                                "secret": {
+                                    "secretName": "${SSO_TRUSTSTORE_SECRET}"
                                 }
                             }
                         ]
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "PersistentVolumeClaim",
-            "metadata": {
-                "name": "${APPLICATION_NAME}-amq-claim",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                }
-            },
-            "spec": {
-                "accessModes": [
-                    "ReadWriteOnce"
-                ],
-                "resources": {
-                    "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
                     }
                 }
             }

--- a/templates/eap74-starter-s2i.json
+++ b/templates/eap74-starter-s2i.json
@@ -5,21 +5,21 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta with passthrough TLS",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0 Starter",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application configured with secure communication using HTTPS. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc",
-            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform application, including a build configuration, application deployment configuration and secure communication using passthrough TLS.",
+            "description": "An example JBoss Enterprise Application Platform application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc",
+            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration and secure communication using edge TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-https-s2i"
+        "name": "eap74-starter-s2i"
     },
     "labels": {
-        "template": "eap74-beta-https-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-starter-s2i",
+        "xpaas": "7.4.0"
     },
-    "message": "A new JBoss EAP based application with SSL support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "message": "A new JBoss EAP based application has been created in your project.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,24 +30,17 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:7.4.0",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "required": true
-        },
-        {
-            "displayName": "Custom https Route Hostname",
-            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix>",
-            "name": "HOSTNAME_HTTPS",
-            "value": "",
-            "required": false
         },
         {
             "displayName": "Git Repository URL",
@@ -84,63 +77,6 @@
             "required": false
         },
         {
-            "displayName": "Queues",
-            "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
-            "name": "MQ_QUEUES",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "Topics",
-            "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
-            "name": "MQ_TOPICS",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "Server Keystore Secret Name",
-            "description": "The name of the secret containing the keystore file",
-            "name": "HTTPS_SECRET",
-            "value": "eap7-app-secret",
-            "required": true
-        },
-        {
-            "displayName": "Server Keystore Filename",
-            "description": "The name of the keystore file within the secret",
-            "name": "HTTPS_KEYSTORE",
-            "value": "keystore.jks",
-            "required": false
-        },
-        {
-            "displayName": "Server Keystore Type",
-            "description": "The type of the keystore file (JKS or JCEKS)",
-            "name": "HTTPS_KEYSTORE_TYPE",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "Server Certificate Name",
-            "description": "The name associated with the server certificate",
-            "name": "HTTPS_NAME",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "Server Keystore Password",
-            "description": "The password for the keystore and certificate",
-            "name": "HTTPS_PASSWORD",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "AMQ cluster password",
-            "description": "AMQ cluster admin password",
-            "name": "MQ_CLUSTER_PASSWORD",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
-            "required": true
-        },
-        {
             "displayName": "Github Webhook Secret",
             "description": "GitHub trigger secret",
             "name": "GITHUB_WEBHOOK_SECRET",
@@ -161,42 +97,6 @@
             "description": "Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.",
             "name": "IMAGE_STREAM_NAMESPACE",
             "value": "openshift",
-            "required": true
-        },
-        {
-            "displayName": "JGroups Secret Name",
-            "description": "The name of the secret containing the keystore file",
-            "name": "JGROUPS_ENCRYPT_SECRET",
-            "value": "eap7-app-secret",
-            "required": false
-        },
-        {
-            "displayName": "JGroups Keystore Filename",
-            "description": "The name of the keystore file within the secret",
-            "name": "JGROUPS_ENCRYPT_KEYSTORE",
-            "value": "jgroups.jceks",
-            "required": false
-        },
-        {
-            "displayName": "JGroups Certificate Name",
-            "description": "The name associated with the server certificate",
-            "name": "JGROUPS_ENCRYPT_NAME",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "JGroups Keystore Password",
-            "description": "The password for the keystore and certificate",
-            "name": "JGROUPS_ENCRYPT_PASSWORD",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "JGroups Cluster Password",
-            "description": "JGroups cluster password",
-            "name": "JGROUPS_CLUSTER_PASSWORD",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
             "required": true
         },
         {
@@ -259,81 +159,11 @@
             }
         },
         {
-            "kind": "Service",
-            "apiVersion": "v1",
-            "spec": {
-                "ports": [
-                    {
-                        "port": 8443,
-                        "targetPort": 8443
-                    }
-                ],
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}"
-                }
-            },
-            "metadata": {
-                "name": "secure-${APPLICATION_NAME}",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "annotations": {
-                    "description": "The web server's https port."
-                }
-            }
-        },
-        {
-            "kind": "Service",
-            "apiVersion": "v1",
-            "spec": {
-                "publishNotReadyAddresses": true,
-                "clusterIP": "None",
-                "ports": [
-                    {
-                        "name": "ping",
-                        "port": 8888
-                    }
-                ],
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}"
-                }
-            },
-            "metadata": {
-                "name": "${APPLICATION_NAME}-ping",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "annotations": {
-                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-                    "description": "The JGroups ping port for clustering."
-                }
-            }
-        },
-        {
-            "kind": "Route",
-            "apiVersion": "v1",
-            "id": "${APPLICATION_NAME}-http",
-            "metadata": {
-                "name": "${APPLICATION_NAME}",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                },
-                "annotations": {
-                    "description": "Route for application's http service."
-                }
-            },
-            "spec": {
-                "to": {
-                    "name": "${APPLICATION_NAME}"
-                }
-            }
-        },
-        {
             "kind": "Route",
             "apiVersion": "v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
-                "name": "secure-${APPLICATION_NAME}",
+                "name": "${APPLICATION_NAME}",
                 "labels": {
                     "application": "${APPLICATION_NAME}"
                 },
@@ -342,12 +172,12 @@
                 }
             },
             "spec": {
-                "host": "${HOSTNAME_HTTPS}",
                 "to": {
-                    "name": "secure-${APPLICATION_NAME}"
+                    "name": "${APPLICATION_NAME}"
                 },
                 "tls": {
-                    "termination": "passthrough"
+                    "insecureEdgeTerminationPolicy": "Redirect",
+                    "termination": "edge"
                 }
             }
         },
@@ -567,18 +397,6 @@
                                         "memory": "${MEMORY_LIMIT}"
                                     }
                                 },
-                                "volumeMounts": [
-                                    {
-                                        "name": "eap-keystore-volume",
-                                        "mountPath": "/etc/eap-secret-volume",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "name": "eap-jgroups-keystore-volume",
-                                        "mountPath": "/etc/jgroups-encrypt-secret-volume",
-                                        "readOnly": true
-                                    }
-                                ],
                                 "livenessProbe": {
                                     "exec": {
                                         "command": [
@@ -609,87 +427,9 @@
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "https",
-                                        "containerPort": 8443,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "name": "ping",
-                                        "containerPort": 8888,
-                                        "protocol": "TCP"
                                     }
                                 ],
                                 "env": [
-                                    {
-                                        "name": "JGROUPS_PING_PROTOCOL",
-                                        "value": "dns.DNS_PING"
-                                    },
-                                    {
-                                        "name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
-                                        "value": "${APPLICATION_NAME}-ping"
-                                    },
-                                    {
-                                        "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
-                                        "value": "8888"
-                                    },
-                                    {
-                                        "name": "HTTPS_KEYSTORE_DIR",
-                                        "value": "/etc/eap-secret-volume"
-                                    },
-                                    {
-                                        "name": "HTTPS_KEYSTORE",
-                                        "value": "${HTTPS_KEYSTORE}"
-                                    },
-                                    {
-                                        "name": "HTTPS_KEYSTORE_TYPE",
-                                        "value": "${HTTPS_KEYSTORE_TYPE}"
-                                    },
-                                    {
-                                        "name": "HTTPS_NAME",
-                                        "value": "${HTTPS_NAME}"
-                                    },
-                                    {
-                                        "name": "HTTPS_PASSWORD",
-                                        "value": "${HTTPS_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "MQ_CLUSTER_PASSWORD",
-                                        "value": "${MQ_CLUSTER_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "MQ_QUEUES",
-                                        "value": "${MQ_QUEUES}"
-                                    },
-                                    {
-                                        "name": "MQ_TOPICS",
-                                        "value": "${MQ_TOPICS}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_SECRET",
-                                        "value": "${JGROUPS_ENCRYPT_SECRET}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_KEYSTORE_DIR",
-                                        "value": "/etc/jgroups-encrypt-secret-volume"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_KEYSTORE",
-                                        "value": "${JGROUPS_ENCRYPT_KEYSTORE}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_NAME",
-                                        "value": "${JGROUPS_ENCRYPT_NAME}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_ENCRYPT_PASSWORD",
-                                        "value": "${JGROUPS_ENCRYPT_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "JGROUPS_CLUSTER_PASSWORD",
-                                        "value": "${JGROUPS_CLUSTER_PASSWORD}"
-                                    },
                                     {
                                         "name": "AUTO_DEPLOY_EXPLODED",
                                         "value": "${AUTO_DEPLOY_EXPLODED}"
@@ -699,20 +439,6 @@
                                         "value": "${ENABLE_GENERATE_DEFAULT_DATASOURCE}"
                                     }
                                 ]
-                            }
-                        ],
-                        "volumes": [
-                            {
-                                "name": "eap-keystore-volume",
-                                "secret": {
-                                    "secretName": "${HTTPS_SECRET}"
-                                }
-                            },
-                            {
-                                "name": "eap-jgroups-keystore-volume",
-                                "secret": {
-                                    "secretName": "${JGROUPS_ENCRYPT_SECRET}"
-                                }
                             }
                         ]
                     }

--- a/templates/eap74-third-party-db-s2i.json
+++ b/templates/eap74-third-party-db-s2i.json
@@ -4,22 +4,22 @@
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
-            "tags": "eap,javaee,java,jboss,hidden",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta + Single Sign-On with passthrough TLS",
+            "tags": "eap,javaee,java,jboss",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0 with passthrough TLS & DB driver examples",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application Single Sign-On application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc",
-            "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration, integrated with Red Hat Single Sign-On and secure communication using passthrough TLS.",
+            "description": "An example JBoss Enterprise Application Platform application. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop JBoss Enterprise Application Server based application, including a build configuration, application deployment configuration, using third-party DB drivers and secure communication using passthrough TLS.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-sso-s2i"
+        "name": "eap74-third-party-db-s2i"
     },
     "labels": {
-        "template": "eap74-beta-sso-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-third-party-db-s2i",
+        "xpaas": "7.4.0"
     },
-    "message": "A new JBoss EAP application with SSL and SSO support has been created in your project. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
+    "message": "A new EAP based application with SSL support has been created in your project. Please be sure to create the following secrets:\"${CONFIGURATION_NAME}\" containing the datasource configuration details required by the deployed application(s);  \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
         {
             "displayName": "Application Name",
@@ -30,53 +30,53 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:latest",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:latest",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "required": true
         },
         {
-            "displayName": "SSO Image Name",
-            "description": "Name of the SSO image to use, examples: redhat-sso74-openshift:latest",
-            "name": "SSO_IMAGE_NAME",
-            "value": "redhat-sso74-openshift:latest",
+            "displayName": "Configuration Secret Name",
+            "description": "The name of the secret containing configuration properties for the datasources.",
+            "name": "CONFIGURATION_NAME",
+            "value": "eap-app-config",
             "required": true
         },
         {
             "displayName": "Custom https Route Hostname",
-            "description": "Hostname for https service route (e.g. secure-eap-app-myproject.example.com).  Required for SSO-enabled applications.  This is added to the white list of redirects in the SSO server.",
+            "description": "Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-<project>.<default-domain-suffix>",
             "name": "HOSTNAME_HTTPS",
             "value": "",
-            "required": true
+            "required": false
         },
         {
             "displayName": "Git Repository URL",
             "description": "Git source URI for application",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/redhat-developer/redhat-sso-quickstarts",
+            "value": "https://github.com/jboss-openshift/openshift-quickstarts",
             "required": true
         },
         {
             "displayName": "Git Reference",
             "description": "Git branch/tag reference",
             "name": "SOURCE_REPOSITORY_REF",
-            "value": "7.0.x-ose",
+            "value": "1.5",
             "required": false
         },
         {
             "displayName": "Context Directory",
             "description": "Path within Git project to build; empty for root project directory.",
             "name": "CONTEXT_DIR",
-            "value": "",
+            "value": "datavirt/hibernate-webapp",
             "required": false
-        },
+        }, 
         {
             "displayName": "Galleon layers",
             "description": "Comma separated list of Galleon layers to provision a server.",
@@ -91,32 +91,45 @@
             "required": false
         },
         {
-            "displayName": "Queues",
+            "displayName": "Drivers ImageStreamTag",
+            "description": "ImageStreamTag definition for the image containing the drivers and configuration, e.g. jboss-datavirt63-driver-openshift:1.1",
+            "name": "EXTENSIONS_IMAGE",
+            "value": "jboss-datavirt63-driver-openshift:1.1",
+            "required": true
+        },
+        {
+            "displayName": "Drivers ImageStream Namespace",
+            "description": "Namespace within which the ImageStream definition for the image containing the drivers and configuration is located.",
+            "name": "EXTENSIONS_IMAGE_NAMESPACE",
+            "value": "openshift",
+            "required": true
+        },
+        {
+            "displayName": "Drivers Image Install Directory",
+            "description": "Full path to the directory within the extensions image where the extensions are located (e.g. install.sh, modules/, etc.)",
+            "name": "EXTENSIONS_INSTALL_DIR",
+            "value": "/extensions",
+            "required": true
+        },
+        {
+            "displayName": "Queue Names",
             "description": "Queue names, separated by commas. These queues will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all queues used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_QUEUES",
             "value": "",
             "required": false
         },
         {
-            "displayName": "Topics",
+            "displayName": "Topic Names",
             "description": "Topic names, separated by commas. These topics will be automatically created when the broker starts. Also, they will be made accessible as JNDI resources in EAP. Note that all topics used by the application *must* be specified here in order to be created automatically on the remote AMQ broker.",
             "name": "MQ_TOPICS",
             "value": "",
             "required": false
         },
         {
-            "displayName": "AMQ cluster password",
-            "description": "AMQ cluster admin password",
-            "name": "MQ_CLUSTER_PASSWORD",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
-            "required": true
-        },
-        {
             "displayName": "Server Keystore Secret Name",
             "description": "The name of the secret containing the keystore file",
             "name": "HTTPS_SECRET",
-            "value": "eap7-app-secret",
+            "value": "eap-app-secret",
             "required": true
         },
         {
@@ -135,21 +148,29 @@
         },
         {
             "displayName": "Server Certificate Name",
-            "description": "The name associated with the server certificate (e.g. jboss)",
+            "description": "The name associated with the server certificate",
             "name": "HTTPS_NAME",
-            "value": "",
+            "value": "jboss",
             "required": false
         },
         {
             "displayName": "Server Keystore Password",
-            "description": "The password for the keystore and certificate (e.g. mykeystorepass)",
+            "description": "The password for the keystore and certificate",
             "name": "HTTPS_PASSWORD",
-            "value": "",
+            "value": "mykeystorepass",
             "required": false
         },
         {
+            "displayName": "Messaging Cluster Admin Password",
+            "description": "Admin password for Messaging cluster.",
+            "name": "MQ_CLUSTER_PASSWORD",
+            "from": "[a-zA-Z0-9]{8}",
+            "generate": "expression",
+            "required": true
+        },
+        {
             "displayName": "Github Webhook Secret",
-            "description": "GitHub trigger secret",
+            "description": "A secret string used to configure the GitHub webhook.",
             "name": "GITHUB_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -157,7 +178,7 @@
         },
         {
             "displayName": "Generic Webhook Secret",
-            "description": "Generic build trigger secret",
+            "description": "A secret string used to configure the Generic webhook.",
             "name": "GENERIC_WEBHOOK_SECRET",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -172,35 +193,35 @@
         },
         {
             "displayName": "JGroups Secret Name",
-            "description": "The name of the secret containing the keystore file",
+            "description": "The name of the secret containing the keystore to be used for securing JGroups communications.",
             "name": "JGROUPS_ENCRYPT_SECRET",
-            "value": "eap7-app-secret",
+            "value": "eap-app-secret",
             "required": false
         },
         {
             "displayName": "JGroups Keystore Filename",
-            "description": "The name of the keystore file within the secret",
+            "description": "The name of the keystore file within the JGroups secret.",
             "name": "JGROUPS_ENCRYPT_KEYSTORE",
             "value": "jgroups.jceks",
             "required": false
         },
         {
             "displayName": "JGroups Certificate Name",
-            "description": "The name associated with the server certificate (e.g. secret-key)",
+            "description": "The name associated with the JGroups server certificate",
             "name": "JGROUPS_ENCRYPT_NAME",
-            "value": "",
+            "value": "secret-key",
             "required": false
         },
         {
             "displayName": "JGroups Keystore Password",
-            "description": "The password for the keystore and certificate (e.g. password)",
+            "description": "The password for the keystore and certificate",
             "name": "JGROUPS_ENCRYPT_PASSWORD",
-            "value": "",
+            "value": "password",
             "required": false
         },
         {
             "displayName": "JGroups Cluster Password",
-            "description": "JGroups cluster password",
+            "description": "Password used by JGroups to authenticate nodes in the cluster.",
             "name": "JGROUPS_CLUSTER_PASSWORD",
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
@@ -214,140 +235,6 @@
             "required": false
         },
         {
-            "displayName": "URL for SSO",
-            "description": "The URL for the SSO server (e.g. https://secure-sso-myproject.example.com/auth).  This is the URL through which the user will be redirected when a login or token is required by the application.",
-            "name": "SSO_URL",
-            "value": "",
-            "required": true
-        },
-        {
-            "displayName": "URL for SSO (internal service)",
-            "description": "The URL for the internal SSO service, where secure-sso (the default) is the kubernetes service exposed by the SSO server.  This is used to create the application client(s) (see SSO_USERNAME).  This can also be the same as SSO_URL.",
-            "name": "SSO_SERVICE_URL",
-            "value": "https://secure-sso:8443/auth",
-            "required": false
-        },
-        {
-            "displayName": "SSO Realm",
-            "description": "The SSO realm to which the application client(s) should be associated (e.g. demo).",
-            "name": "SSO_REALM",
-            "value": "",
-            "required": true
-        },
-        {
-            "displayName": "SSO Username",
-            "description": "The username used to access the SSO service.  This is used to create the appliction client(s) within the specified SSO realm. This should match the SSO_SERVICE_USERNAME specified through one of the sso70-* templates.",
-            "name": "SSO_USERNAME",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "SSO Password",
-            "description": "The password for the SSO service user.",
-            "name": "SSO_PASSWORD",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "SSO Public Key",
-            "description": "SSO Public Key. Public key is recommended to be passed into the template to avoid man-in-the-middle security vulnerability",
-            "name": "SSO_PUBLIC_KEY",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "SSO Bearer Only?",
-            "description": "SSO Client Access Type",
-            "name": "SSO_BEARER_ONLY",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "Artifact Directories",
-            "description": "List of directories from which archives will be copied into the deployment folder.  If unspecified, all archives in /target will be copied.",
-            "name": "ARTIFACT_DIR",
-            "value": "app-jee-jsp/target,service-jee-jaxrs/target,app-profile-jee-jsp/target,app-profile-saml-jee-jsp/target",
-            "required": false
-        },
-        {
-            "displayName": "SSO SAML Keystore Secret",
-            "description": "The name of the secret containing the keystore file",
-            "name": "SSO_SAML_KEYSTORE_SECRET",
-            "value": "eap7-app-secret",
-            "required": false
-        },
-        {
-            "displayName": "SSO SAML Keystore",
-            "description": "The name of the keystore file within the secret",
-            "name": "SSO_SAML_KEYSTORE",
-            "value": "keystore.jks",
-            "required": false
-        },
-        {
-            "displayName": "SSO SAML Certificate Name",
-            "description": "The name associated with the server certificate",
-            "name": "SSO_SAML_CERTIFICATE_NAME",
-            "value": "jboss",
-            "required": false
-        },
-        {
-            "displayName": "SSO SAML Keystore Password",
-            "description": "The password for the keystore and certificate",
-            "name": "SSO_SAML_KEYSTORE_PASSWORD",
-            "value": "mykeystorepass",
-            "required": false
-        },
-        {
-            "displayName": "SSO Client Secret",
-            "description": "The SSO Client Secret for Confidential Access",
-            "name": "SSO_SECRET",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
-            "required": true
-        },
-        {
-            "displayName": "Enable CORS for SSO?",
-            "description": "Enable CORS for SSO applications",
-            "name": "SSO_ENABLE_CORS",
-            "value": "false",
-            "required": false
-        },
-        {
-            "displayName": "SSO SAML Logout Page",
-            "description": "SSO logout page for SAML applications",
-            "name": "SSO_SAML_LOGOUT_PAGE",
-            "value": "/",
-            "required": false
-        },
-        {
-            "displayName": "Disable SSL Validation in EAP->SSO communication",
-            "description": "If true SSL communication between EAP and the SSO Server will be insecure (i.e. certificate validation is disabled with curl)",
-            "name": "SSO_DISABLE_SSL_CERTIFICATE_VALIDATION",
-            "value": "true",
-            "required": false
-        },
-        {
-            "displayName": "SSO Trust Store",
-            "description": "The name of the truststore file within the secret (e.g. truststore.jks)",
-            "name": "SSO_TRUSTSTORE",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "SSO Trust Store Password",
-            "description": "The password for the truststore and certificate (e.g. mykeystorepass)",
-            "name": "SSO_TRUSTSTORE_PASSWORD",
-            "value": "",
-            "required": false
-        },
-        {
-            "displayName": "SSO Trust Store Secret",
-            "description": "The name of the secret containing the truststore file (e.g. truststore-secret). Used for volume secretName",
-            "name": "SSO_TRUSTSTORE_SECRET",
-            "value": "eap7-app-secret",
-            "required": false
-        },
-        {
             "displayName": "Maven mirror URL",
             "description": "Maven mirror to use for S2I builds",
             "name": "MAVEN_MIRROR_URL",
@@ -358,6 +245,12 @@
             "displayName": "Maven Additional Arguments",
             "description": "Maven additional arguments to use for S2I builds",
             "name": "MAVEN_ARGS_APPEND",
+            "value": "",
+            "required": false
+        },
+        {
+            "description": "List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.",
+            "name": "ARTIFACT_DIR",
             "value": "",
             "required": false
         },
@@ -527,13 +420,13 @@
                         {
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "${SSO_IMAGE_NAME}"
+                                "namespace": "${EXTENSIONS_IMAGE_NAMESPACE}",
+                                "name": "${EXTENSIONS_IMAGE}"
                             },
                             "paths": [
                                 {
-                                    "destinationDir": "./${CONTEXT_DIR}/extensions/sso-adapters",
-                                    "sourcePath": "/opt/rh/rh-sso/client/eap7/."
+                                    "destinationDir": "./${CONTEXT_DIR}/extensions/extras",
+                                    "sourcePath": "${EXTENSIONS_INSTALL_DIR}/."
                                 }
                             ]
                         }
@@ -542,22 +435,7 @@
                 "strategy": {
                     "type": "Source",
                     "sourceStrategy": {
-                        "forcePull": true,
-                        "incremental": true,
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "${EAP_IMAGE_NAME}"
-                        },
                         "env": [
-                            {
-                                "name": "CUSTOM_INSTALL_DIRECTORIES",
-                                "value": "extensions/*"
-                            },
-                            {
-                                "name": "ARTIFACT_DIR",
-                                "value": "${ARTIFACT_DIR}"
-                            },
                             {
                                 "name": "MAVEN_MIRROR_URL",
                                 "value": "${MAVEN_MIRROR_URL}"
@@ -573,8 +451,23 @@
                             {
                                 "name": "GALLEON_PROVISION_DEFAULT_FAT_SERVER",
                                 "value": "true"
+                            },
+                            {
+                                "name": "CUSTOM_INSTALL_DIRECTORIES",
+                                "value": "extensions/*"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR",
+                                "value": "${ARTIFACT_DIR}"
                             }
-                        ]
+                        ],
+                        "forcePull": true,
+                        "incremental": true,
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "namespace": "${IMAGE_STREAM_NAMESPACE}",
+                            "name": "${EAP_IMAGE_NAME}"
+                        }
                     }
                 },
                 "output": {
@@ -599,6 +492,16 @@
                     {
                         "type": "ImageChange",
                         "imageChange": {}
+                    },
+                    {
+                        "type": "ImageChange",
+                        "imageChange": {
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${EXTENSIONS_IMAGE_NAMESPACE}",
+                                "name": "${EXTENSIONS_IMAGE}"
+                            }
+                        }
                     },
                     {
                         "type": "ConfigChange"
@@ -723,8 +626,8 @@
                                 },
                                 "volumeMounts": [
                                     {
-                                        "name": "sso-saml-keystore-volume",
-                                        "mountPath": "/etc/sso-saml-secret-volume",
+                                        "name": "configuration",
+                                        "mountPath": "/etc/eap-environment",
                                         "readOnly": true
                                     },
                                     {
@@ -735,11 +638,6 @@
                                     {
                                         "name": "eap-jgroups-keystore-volume",
                                         "mountPath": "/etc/jgroups-encrypt-secret-volume",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "name": "sso-truststore-volume",
-                                        "mountPath": "/etc/sso-secret-volume",
                                         "readOnly": true
                                     }
                                 ],
@@ -799,12 +697,8 @@
                                         "value": "8888"
                                     },
                                     {
-                                        "name": "HOSTNAME_HTTP",
-                                        "value": "${HOSTNAME_HTTP}"
-                                    },
-                                    {
-                                        "name": "HOSTNAME_HTTPS",
-                                        "value": "${HOSTNAME_HTTPS}"
+                                        "name": "ENV_FILES",
+                                        "value": "/etc/eap-environment/*"
                                     },
                                     {
                                         "name": "HTTPS_KEYSTORE_DIR",
@@ -867,82 +761,6 @@
                                         "value": "${AUTO_DEPLOY_EXPLODED}"
                                     },
                                     {
-                                        "name": "SSO_URL",
-                                        "value": "${SSO_URL}"
-                                    },
-                                    {
-                                        "name": "SSO_SERVICE_URL",
-                                        "value": "${SSO_SERVICE_URL}"
-                                    },
-                                    {
-                                        "name": "SSO_REALM",
-                                        "value": "${SSO_REALM}"
-                                    },
-                                    {
-                                        "name": "SSO_USERNAME",
-                                        "value": "${SSO_USERNAME}"
-                                    },
-                                    {
-                                        "name": "SSO_PASSWORD",
-                                        "value": "${SSO_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "SSO_PUBLIC_KEY",
-                                        "value": "${SSO_PUBLIC_KEY}"
-                                    },
-                                    {
-                                        "name": "SSO_BEARER_ONLY",
-                                        "value": "${SSO_BEARER_ONLY}"
-                                    },
-                                    {
-                                        "name": "SSO_SAML_KEYSTORE_SECRET",
-                                        "value": "${SSO_SAML_KEYSTORE_SECRET}"
-                                    },
-                                    {
-                                        "name": "SSO_SAML_KEYSTORE",
-                                        "value": "${SSO_SAML_KEYSTORE}"
-                                    },
-                                    {
-                                        "name": "SSO_SAML_KEYSTORE_DIR",
-                                        "value": "/etc/sso-saml-secret-volume"
-                                    },
-                                    {
-                                        "name": "SSO_SAML_CERTIFICATE_NAME",
-                                        "value": "${SSO_SAML_CERTIFICATE_NAME}"
-                                    },
-                                    {
-                                        "name": "SSO_SAML_KEYSTORE_PASSWORD",
-                                        "value": "${SSO_SAML_KEYSTORE_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "SSO_SECRET",
-                                        "value": "${SSO_SECRET}"
-                                    },
-                                    {
-                                        "name": "SSO_ENABLE_CORS",
-                                        "value": "${SSO_ENABLE_CORS}"
-                                    },
-                                    {
-                                        "name": "SSO_SAML_LOGOUT_PAGE",
-                                        "value": "${SSO_SAML_LOGOUT_PAGE}"
-                                    },
-                                    {
-                                        "name": "SSO_DISABLE_SSL_CERTIFICATE_VALIDATION",
-                                        "value": "${SSO_DISABLE_SSL_CERTIFICATE_VALIDATION}"
-                                    },
-                                    {
-                                        "name": "SSO_TRUSTSTORE",
-                                        "value": "${SSO_TRUSTSTORE}"
-                                    },
-                                    {
-                                        "name": "SSO_TRUSTSTORE_DIR",
-                                        "value": "/etc/sso-secret-volume"
-                                    },
-                                    {
-                                        "name": "SSO_TRUSTSTORE_PASSWORD",
-                                        "value": "${SSO_TRUSTSTORE_PASSWORD}"
-                                    },
-                                    {
                                         "name": "ENABLE_GENERATE_DEFAULT_DATASOURCE",
                                         "value": "${ENABLE_GENERATE_DEFAULT_DATASOURCE}"
                                     }
@@ -951,9 +769,9 @@
                         ],
                         "volumes": [
                             {
-                                "name": "sso-saml-keystore-volume",
+                                "name": "configuration",
                                 "secret": {
-                                    "secretName": "${SSO_SAML_KEYSTORE_SECRET}"
+                                    "secretName": "${CONFIGURATION_NAME}"
                                 }
                             },
                             {
@@ -966,12 +784,6 @@
                                 "name": "eap-jgroups-keystore-volume",
                                 "secret": {
                                     "secretName": "${JGROUPS_ENCRYPT_SECRET}"
-                                }
-                            },
-                            {
-                                "name": "sso-truststore-volume",
-                                "secret": {
-                                    "secretName": "${SSO_TRUSTSTORE_SECRET}"
                                 }
                             }
                         ]

--- a/templates/eap74-tx-recovery-s2i.json
+++ b/templates/eap74-tx-recovery-s2i.json
@@ -5,19 +5,19 @@
         "annotations": {
             "iconClass": "icon-eap",
             "tags": "eap,javaee,java,jboss,hidden",
-            "version": "7.4.0.Beta",
-            "openshift.io/display-name": "JBoss EAP 7.4.0.Beta + AMQ 7 (tx recovery)",
+            "version": "7.4.0",
+            "openshift.io/display-name": "JBoss EAP 7.4.0 + AMQ 7 (tx recovery)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An example JBoss Enterprise Application Platform application with transaction recovery configured. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74-beta/README.adoc",
+            "description": "An example JBoss Enterprise Application Platform application with transaction recovery configured. For more information about using this template, see https://github.com/jboss-container-images/jboss-eap-7-openshift-image/blob/eap74/README.adoc",
             "template.openshift.io/long-description": "This template defines resources needed to develop a JBoss Enterprise Application Platform based application, including a build configuration, application deployment configuration and insecure communication using http. The template also demonstrates how to enable automated transaction recovery on scale down of application pods.  Automated transaction recovery is currently Technology Preview.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
-        "name": "eap74-beta-tx-recovery-s2i"
+        "name": "eap74-tx-recovery-s2i"
     },
     "labels": {
-        "template": "eap74-beta-tx-recovery-s2i",
-        "xpaas": "7.4.0.Beta"
+        "template": "eap74-tx-recovery-s2i",
+        "xpaas": "7.4.0"
     },
     "message": "A new JBoss EAP based application has been created in your project.",
     "parameters": [
@@ -30,16 +30,16 @@
         },
         {
             "displayName": "EAP Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-openshift:latest",
             "name": "EAP_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-openshift:7.4.0",
             "required": true
         },
         {
             "displayName": "EAP Runtime Image Name",
-            "description": "Name of the EAP image to use, example: jboss-eap74-beta-openjdk11-runtime-openshift:latest",
+            "description": "Name of the EAP image to use, example: jboss-eap74-openjdk11-runtime-openshift:latest",
             "name": "EAP_RUNTIME_IMAGE_NAME",
-            "value": "jboss-eap74-beta-openjdk11-runtime-openshift:7.4.0.Beta",
+            "value": "jboss-eap74-openjdk11-runtime-openshift:7.4.0",
             "required": true
         },
         {


### PR DESCRIPTION
* replace eap74-beta with eap74
* replace 7.4.0.Beta with 7.4.0
* replace jboss-eap-7-tech-preview with jboss-eap-7
* rename all files from eap74-beta-xxx to eap74-xxx
* rename the imagestreams list names to
   jboss-eap74-xxx-openshift-image-streams

JIRA: https://issues.redhat.com/browse/CLOUD-3939

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>