### PR TITLE
[CLOUD-3943] Add metering labels for EAP 7.4

### DIFF
--- a/templates/eap74-amq-persistent-s2i.json
+++ b/templates/eap74-amq-persistent-s2i.json
@@ -667,7 +667,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-amq-s2i.json
+++ b/templates/eap74-amq-s2i.json
@@ -653,7 +653,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-basic-s2i.json
+++ b/templates/eap74-basic-s2i.json
@@ -439,7 +439,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-https-s2i.json
+++ b/templates/eap74-https-s2i.json
@@ -552,7 +552,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-sso-s2i.json
+++ b/templates/eap74-sso-s2i.json
@@ -706,7 +706,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-starter-s2i.json
+++ b/templates/eap74-starter-s2i.json
@@ -382,7 +382,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-third-party-db-s2i.json
+++ b/templates/eap74-third-party-db-s2i.json
@@ -609,7 +609,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-tx-recovery-s2i.json
+++ b/templates/eap74-tx-recovery-s2i.json
@@ -601,7 +601,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q2",
+                            "com.redhat.component-name": "EAP",
+                            "com.redhat.component-version": "7.4",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {


### PR DESCRIPTION
* Identify EAP 7.4 workload by adding metering lables
  to the deploymentConfig's template metadata

JIRA: https://issues.redhat.com/browse/CLOUD-3943

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>