### PR TITLE
CLOUD-3945 Imagestreams should have a :latest tag

### DIFF
--- a/eap74-openj9-11-image-stream.json
+++ b/eap74-openj9-11-image-stream.json
@@ -26,6 +26,27 @@
             "spec": {
                 "tags": [
                     {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 with OpenJDK 11 + OpenJ9",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:11",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK11 + OpenJ9"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openj9-11-openshift-rhel8:latest"
+                        }
+                    },
+                    {
                         "name": "7.4.0",
                         "annotations": {
                             "description": "The latest available build of JBoss EAP 7.4.0 with OpenJDK 11 + OpenJ9",
@@ -66,6 +87,27 @@
             "spec": {
                 "tags": [
                     {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK11 + OpenJ9",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:11",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK11 + OpenJ9 (Runtime Image)"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openj9-11-runtime-openshift-rhel8:latest"
+                        }
+                    },        
+                    {
                         "name": "7.4.0",
                         "annotations": {
                             "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK11 + OpenJ9",
@@ -83,7 +125,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7/eap74-openj9-11-runtime-openshift-rhel8"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openj9-11-runtime-openshift-rhel8:latest"
                         }
                     }                ]
             }

--- a/eap74-openjdk11-image-stream.json
+++ b/eap74-openjdk11-image-stream.json
@@ -26,6 +26,27 @@
             "spec": {
                 "tags": [
                     {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 with OpenJDK 11.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:11",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk11-openshift-rhel8:latest"
+                        }
+                    },
+                    {
                         "name": "7.4.0",
                         "annotations": {
                             "description": "The latest available build of JBoss EAP 7.4.0 with OpenJDK 11.",
@@ -66,6 +87,27 @@
             "spec": {
                 "tags": [
                     {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK 11.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:11",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK11"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk11-runtime-openshift-rhel8:latest"
+                        }
+                    },
+                    {
                         "name": "7.4.0",
                         "annotations": {
                             "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 11",
@@ -83,7 +125,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk11-runtime-openshift-rhel8"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk11-runtime-openshift-rhel8:latest"
                         }
                     }
                 ]

--- a/eap74-openjdk8-image-stream.json
+++ b/eap74-openjdk8-image-stream.json
@@ -26,9 +26,30 @@
             "spec": {
                 "tags": [
                     {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 builder image with OpenJDK 8.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
+                        }
+                    },
+                    {
                         "name": "7.4.0",
                         "annotations": {
-                            "description": "JBoss EAP 7.4.0",
+                            "description": "The latest available build of JBoss EAP 7.4.0 builder image with OpenJDK 8.",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
                             "supports": "eap:7.4.0,javaee:8,java:8",
@@ -65,6 +86,27 @@
             },
             "spec": {
                 "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK 8",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK 8 (Runtime Image)"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel7:latest"
+                        }
+                    },
                     {
                         "name": "7.4.0",
                         "annotations": {


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-3945
Signed-off-by: Ken Wills <kwills@redhat.com>