### PR TITLE
[JBEAP-21566] add missing HOSTNAME_HTTP parameter that is used in HOS…

### DIFF
--- a/templates/eap74-sso-s2i.json
+++ b/templates/eap74-sso-s2i.json
@@ -50,6 +50,13 @@
             "required": true
         },
         {
+            "displayName": "Custom http Route Hostname",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix>",
+            "name": "HOSTNAME_HTTP",
+            "value": "",
+            "required": false
+        },
+        {
             "displayName": "Custom https Route Hostname",
             "description": "Hostname for https service route (e.g. secure-eap-app-myproject.example.com).  Required for SSO-enabled applications.  This is added to the white list of redirects in the SSO server.",
             "name": "HOSTNAME_HTTPS",


### PR DESCRIPTION
…TNAME_HTTP env variable

The parameter HOSTNAME_HTTP is not present although an env variable HOSTNAME_HTTP is defined in the container. Its values is the string "${HOSTNAME_HTTP}".

https://issues.redhat.com/browse/JBEAP-21566

completely untested for now