### PR TITLE
[CLOUD-4013] Add metering labels for EAP XP3

### DIFF
--- a/templates/eap-xp3-basic-s2i.json
+++ b/templates/eap-xp3-basic-s2i.json
@@ -439,7 +439,13 @@
                         "name": "${APPLICATION_NAME}",
                         "labels": {
                             "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
+                            "application": "${APPLICATION_NAME}",
+                            "com.company": "Red_Hat",
+                            "com.redhat.product-name": "Red_Hat_Runtimes",
+                            "com.redhat.product-version": "2021-Q3",
+                            "com.redhat.component-name": "EAP_XP",
+                            "com.redhat.component-version": "3.0",
+                            "com.redhat.component-type": "application"
                         }
                     },
                     "spec": {


### PR DESCRIPTION
* Identify EAP XP 3 workload by adding metering lables
  to the deploymentConfig's template metadata

JIRA: https://issues.redhat.com/browse/CLOUD-4013

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>