### PR TITLE
[CLOUD-4014] Fix dockerImage for eap74-openjdk8 imagestream

### DIFF
--- a/eap74-openjdk8-image-stream.json
+++ b/eap74-openjdk8-image-stream.json
@@ -43,7 +43,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel7:latest"
                         }
                     },
                     {
@@ -64,7 +64,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel7:latest"
                         }
                     }
                 ]


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/CLOUD-4014

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>