### PR TITLE
[JBEAP-20272] Trigger rebuild also on change of EAP_RUNTIME_IMAGE

### DIFF
--- a/eap-s2i-build.yaml
+++ b/eap-s2i-build.yaml
@@ -108,6 +108,8 @@ objects:
         imageOptimizationPolicy: SkipLayers
       type: Docker
     triggers:
+    - imageChange: {}
+      type: ImageChange
     - imageChange:
         from:
           kind: ImageStreamTag


### PR DESCRIPTION
https://issues.redhat.com/browse/JBEAP-20272

This will trigger rebuild of application imagestream tag when there is a change to imagestream tag specified by EAP_RUNTIME_IMAGE

ref https://docs.openshift.com/container-platform/4.8/cicd/builds/triggering-builds-build-hooks.html#builds-using-image-change-triggers_triggering-builds-build-hooks