### PR TITLE
[EAP7-1814] Update metering labels

### DIFF
--- a/templates/eap74-amq-persistent-s2i.json
+++ b/templates/eap74-amq-persistent-s2i.json
@@ -669,11 +669,11 @@
                             "deploymentConfig": "${APPLICATION_NAME}",
                             "application": "${APPLICATION_NAME}",
                             "com.company": "Red_Hat",
-                            "com.redhat.product-name": "Red_Hat_Runtimes",
-                            "com.redhat.product-version": "2021-Q2",
-                            "com.redhat.component-name": "EAP",
-                            "com.redhat.component-version": "7.4",
-                            "com.redhat.component-type": "application"
+                            "rht.prod_name": "Red_Hat_Runtimes",
+                            "rht.prod_ver": "2022-Q1",
+                            "rht.comp": "EAP",
+                            "rht.comp_ver": "7.4",
+                            "rht.subcomp_t": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-amq-s2i.json
+++ b/templates/eap74-amq-s2i.json
@@ -655,11 +655,11 @@
                             "deploymentConfig": "${APPLICATION_NAME}",
                             "application": "${APPLICATION_NAME}",
                             "com.company": "Red_Hat",
-                            "com.redhat.product-name": "Red_Hat_Runtimes",
-                            "com.redhat.product-version": "2021-Q2",
-                            "com.redhat.component-name": "EAP",
-                            "com.redhat.component-version": "7.4",
-                            "com.redhat.component-type": "application"
+                            "rht.prod_name": "Red_Hat_Runtimes",
+                            "rht.prod_ver": "2022-Q1",
+                            "rht.comp": "EAP",
+                            "rht.comp_ver": "7.4",
+                            "rht.subcomp_t": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-basic-s2i.json
+++ b/templates/eap74-basic-s2i.json
@@ -441,11 +441,11 @@
                             "deploymentConfig": "${APPLICATION_NAME}",
                             "application": "${APPLICATION_NAME}",
                             "com.company": "Red_Hat",
-                            "com.redhat.product-name": "Red_Hat_Runtimes",
-                            "com.redhat.product-version": "2021-Q2",
-                            "com.redhat.component-name": "EAP",
-                            "com.redhat.component-version": "7.4",
-                            "com.redhat.component-type": "application"
+                            "rht.prod_name": "Red_Hat_Runtimes",
+                            "rht.prod_ver": "2022-Q1",
+                            "rht.comp": "EAP",
+                            "rht.comp_ver": "7.4",
+                            "rht.subcomp_t": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-https-s2i.json
+++ b/templates/eap74-https-s2i.json
@@ -554,11 +554,11 @@
                             "deploymentConfig": "${APPLICATION_NAME}",
                             "application": "${APPLICATION_NAME}",
                             "com.company": "Red_Hat",
-                            "com.redhat.product-name": "Red_Hat_Runtimes",
-                            "com.redhat.product-version": "2021-Q2",
-                            "com.redhat.component-name": "EAP",
-                            "com.redhat.component-version": "7.4",
-                            "com.redhat.component-type": "application"
+                            "rht.prod_name": "Red_Hat_Runtimes",
+                            "rht.prod_ver": "2022-Q1",
+                            "rht.comp": "EAP",
+                            "rht.comp_ver": "7.4",
+                            "rht.subcomp_t": "application"
                         }
                     },
                     "spec": {

--- a/templates/eap74-sso-s2i.json
+++ b/templates/eap74-sso-s2i.json
@@ -715,11 +715,11 @@
                             "deploymentConfig": "${APPLICATION_NAME}",
                             "application": "${APPLICATION_NAME}",
                             "com.company": "Red_Hat",
-                            "com.redhat.product-name": "Red_Hat_Runtimes",
-                            "com.redhat.product-version": "2021-Q2",
-                            "com.redhat.component-name": "EAP",
-                            "com.redhat.component-version": "7.4",
-                            "com.redhat.component-type": "application"
+                            "rht.prod_name": "Red_Hat_Runtimes",
+                            "rht.prod_ver": "2022-Q1",
+                            "rht.comp": "EAP",
+                            "rht.comp_ver": "7.4",
+                            "rht.subcomp_t": "application"
                         }
                     },
                     "spec": {


### PR DESCRIPTION
Change the metering labels to comply with Red Hat convention

* com.redhat.product-name -> rht.prod_name
* com.redhat.product-version -> rht.prod_ver
* com.redhat.component-name -> rht.comp
* com.redhat.component-version -> rht.comp_ver
* com.redhat.component-type -> rht.subcomp_t

Update the product version from "2021-Q3" to "2022-Q1"

JIRA: https://issues.redhat.com/browse/EAP7-1814

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>