### PR TITLE
[EAP7-1814] Update metering labels

### DIFF
--- a/templates/eap-xp3-basic-s2i.json
+++ b/templates/eap-xp3-basic-s2i.json
@@ -441,11 +441,11 @@
                             "deploymentConfig": "${APPLICATION_NAME}",
                             "application": "${APPLICATION_NAME}",
                             "com.company": "Red_Hat",
-                            "com.redhat.product-name": "Red_Hat_Runtimes",
-                            "com.redhat.product-version": "2021-Q3",
-                            "com.redhat.component-name": "EAP_XP",
-                            "com.redhat.component-version": "3.0",
-                            "com.redhat.component-type": "application"
+                            "rht.prod_name": "Red_Hat_Runtimes",
+                            "rht.prod_ver": "2022-Q1",
+                            "rht.comp": "EAP_XP",
+                            "rht.comp_ver": "3.0",
+                            "rht.subcomp_t": "application"
                         }
                     },
                     "spec": {


### PR DESCRIPTION
Change the metering labels to comply with Red Hat convention

* com.redhat.product-name -> rht.prod_name
* com.redhat.product-version -> rht.prod_ver
* com.redhat.component-name -> rht.comp
* com.redhat.component-version -> rht.comp_ver
* com.redhat.component-type -> rht.subcomp_t

Update the product version from "2021-Q3" to "2022-Q1"

JIRA: https://issues.redhat.com/browse/EAP7-1814

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>