### PR TITLE
[JBEAP-23082] Fix warning due to incorrect value of ImageStream and Template apiVersion.

### DIFF
--- a/eap74-openj9-11-image-stream.json
+++ b/eap74-openj9-11-image-stream.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-eap74-openj9-11-openshift",
                 "annotations": {
@@ -72,7 +72,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-eap74-openj9-11-runtime-openshift",
                 "annotations": {

--- a/eap74-openjdk11-image-stream.json
+++ b/eap74-openjdk11-image-stream.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-eap74-openjdk11-openshift",
                 "annotations": {
@@ -72,7 +72,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-eap74-openjdk11-runtime-openshift",
                 "annotations": {

--- a/eap74-openjdk8-image-stream.json
+++ b/eap74-openjdk8-image-stream.json
@@ -11,7 +11,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-eap74-openjdk8-openshift",
                 "annotations": {
@@ -72,7 +72,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-eap74-openjdk8-runtime-openshift",
                 "annotations": {

--- a/templates/eap74-amq-persistent-s2i.json
+++ b/templates/eap74-amq-persistent-s2i.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
@@ -426,7 +426,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -445,7 +445,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -468,7 +468,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -478,7 +478,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -488,7 +488,7 @@
         },
         {
             "kind": "BuildConfig",
-            "apiVersion": "v1",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -568,8 +568,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "BuildConfig",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -629,7 +629,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -862,7 +862,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-amq",
                 "labels": {
@@ -1040,8 +1040,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-amq-claim",
                 "labels": {

--- a/templates/eap74-amq-s2i.json
+++ b/templates/eap74-amq-s2i.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
@@ -412,7 +412,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -431,7 +431,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -454,7 +454,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -464,7 +464,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -474,7 +474,7 @@
         },
         {
             "kind": "BuildConfig",
-            "apiVersion": "v1",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -554,8 +554,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "BuildConfig",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -615,7 +615,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -852,7 +852,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-amq",
                 "labels": {

--- a/templates/eap74-basic-s2i.json
+++ b/templates/eap74-basic-s2i.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
@@ -217,7 +217,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -240,7 +240,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -250,7 +250,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -260,7 +260,7 @@
         },
         {
             "kind": "BuildConfig",
-            "apiVersion": "v1",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -340,8 +340,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "BuildConfig",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -401,7 +401,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/eap74-https-s2i.json
+++ b/templates/eap74-https-s2i.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
@@ -311,7 +311,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -330,7 +330,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -353,7 +353,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -363,7 +363,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -373,7 +373,7 @@
         },
         {
             "kind": "BuildConfig",
-            "apiVersion": "v1",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -453,8 +453,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "BuildConfig",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -514,7 +514,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/eap74-sso-s2i.json
+++ b/templates/eap74-sso-s2i.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "annotations": {
             "iconClass": "icon-eap",
@@ -453,7 +453,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-http",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
@@ -472,7 +472,7 @@
         },
         {
             "kind": "Route",
-            "apiVersion": "v1",
+            "apiVersion": "route.openshift.io/v1",
             "id": "${APPLICATION_NAME}-https",
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
@@ -495,7 +495,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
@@ -505,7 +505,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -515,7 +515,7 @@
         },
         {
             "kind": "BuildConfig",
-            "apiVersion": "v1",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}-build-artifacts",
                 "labels": {
@@ -614,8 +614,8 @@
             }
         },
         {
-            "apiVersion": "v1",
             "kind": "BuildConfig",
+            "apiVersion": "build.openshift.io/v1",
             "metadata": {
                 "labels": {
                     "application": "${APPLICATION_NAME}"
@@ -675,7 +675,7 @@
         },
         {
             "kind": "DeploymentConfig",
-            "apiVersion": "v1",
+            "apiVersion": "apps.openshift.io/v1",
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {

--- a/templates/eap74-sso-s2i.json
+++ b/templates/eap74-sso-s2i.json
@@ -44,9 +44,9 @@
         },
         {
             "displayName": "SSO Image Name",
-            "description": "Name of the SSO image to use, example: sso74-openshift-rhel8:latest",
+            "description": "Name of the SSO image to use, example: sso75-openshift-rhel8:latest",
             "name": "SSO_IMAGE_NAME",
-            "value": "sso74-openshift-rhel8:latest",
+            "value": "sso75-openshift-rhel8:latest",
             "required": true
         },
         {


### PR DESCRIPTION
This PR also updates the SSO template to use `sso75-openshift-rhel8:latest` as the previous image is removed from OpenShift library.

JIRA: https://issues.redhat.com/browse/JBEAP-23082