### PR TITLE
[CLOUD-4141] Use groupified API versions in eap-s2i-build.yaml

### DIFF
--- a/eap-s2i-build.yaml
+++ b/eap-s2i-build.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
   template: eap-s2i-build
@@ -17,18 +17,18 @@ metadata:
     template.openshift.io/support-url: https://access.redhat.com
   name: eap-s2i-build
 objects:
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: ${APPLICATION_IMAGE}
   spec:
     lookupPolicy:
       local: true
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: ${APPLICATION_IMAGE}-build-artifacts
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: ${APPLICATION_IMAGE}-build-artifacts
@@ -75,7 +75,7 @@ objects:
     - imageChange: {}
       type: ImageChange
     - type: ConfigChange
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     name: ${APPLICATION_IMAGE}


### PR DESCRIPTION
This is a follow-up to the recent issues like https://issues.redhat.com/browse/JBEAP-23082.
Seems we forgot this one causing issues with latest client versions.

Issue: https://issues.redhat.com/browse/CLOUD-4141