### PR TITLE
Fix Using non-groupfied API resources is deprecated

### DIFF
--- a/eap-s2i-build.yaml
+++ b/eap-s2i-build.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 labels:
   template: eap-s2i-build


### PR DESCRIPTION
This PR fixes the following error that you get if you use oc client 4.11.12 or higher:
```
oc replace --force -f https://github.com/jboss-container-images/jboss-eap-openshift-templates/raw/master/eap-s2i-build.yaml
error: resource mapping not found for name: "eap-s2i-build" namespace: "" from "https://github.com/jboss-container-images/jboss-eap-openshift-templates/raw/master/eap-s2i-build.yaml": no matches for kind "Template" in version "v1"
ensure CRDs are installed first
```