### PR TITLE
Add image stream for JDK8 + RHEL8

### DIFF
--- a/eap74-openjdk8-rhel8-image-stream.json
+++ b/eap74-openjdk8-rhel8-image-stream.json
@@ -1,0 +1,135 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "jboss-eap74-openjdk8-rhel8-openshift-image-streams",
+        "annotations": {
+            "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0 with OpenJDK 8 and RHEL 8",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "jboss-eap74-openjdk8-rhel8-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 and RHEL 8",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "7.4.0"
+                }
+            },
+            "labels": {
+                "xpaas": "7.4.0"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 builder image with OpenJDK 8 and RHEL8.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK8 and RHEL 8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
+                        }
+                    },
+                    {
+                        "name": "7.4.0",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4.0 builder image with OpenJDK 8 and RHEL8.",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4.0,javaee:8,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK8 and RHEL8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "jboss-eap74-openjdk8-rhel8-runtime-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK 8 and RHEL8",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "7.4.0"
+                }
+            },
+            "labels": {
+                "xpaas": "7.4.0"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK 8 and RHEL8",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4,javaee:8,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK 8 (Runtime Image) and RHEL8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel8:latest"
+                        }
+                    },
+                    {
+                        "name": "7.4.0",
+                        "annotations": {
+                            "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 8 and RHEL8",
+                            "iconClass": "icon-eap",
+                            "tags": "builder,eap,javaee,java,jboss,hidden",
+                            "supports": "eap:7.4.0,javaee:8,java:8",
+                            "sampleRepo": "https://github.com/jbossas/eap-quickstarts/",
+                            "sampleContextDir": "kitchensink",
+                            "sampleRef": "7.4.x",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 (Runtime Image) and RHEL8"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel8:latest"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/eap74-openjdk8-rhel8-image-stream.json
+++ b/eap74-openjdk8-rhel8-image-stream.json
@@ -4,7 +4,7 @@
     "metadata": {
         "name": "jboss-eap74-openjdk8-rhel8-openshift-image-streams",
         "annotations": {
-            "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0 with OpenJDK 8 and RHEL 8",
+            "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0 with OpenJDK 8 based on UBI 8",
             "openshift.io/provider-display-name": "Red Hat, Inc."
         }
     },
@@ -15,7 +15,7 @@
             "metadata": {
                 "name": "jboss-eap74-openjdk8-rhel8-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 and RHEL 8",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "7.4.0"
                 }
@@ -28,7 +28,7 @@
                     {
                         "name": "latest",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4 builder image with OpenJDK 8 and RHEL8.",
+                            "description": "The latest available build of JBoss EAP 7.4 builder image with OpenJDK 8.",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
                             "supports": "eap:7.4,javaee:8,java:8",
@@ -36,7 +36,7 @@
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK8 and RHEL 8"
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK8"
                         },
                         "referencePolicy": {
                             "type": "Local"
@@ -49,7 +49,7 @@
                     {
                         "name": "7.4.0",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4.0 builder image with OpenJDK 8 and RHEL8.",
+                            "description": "The latest available build of JBoss EAP 7.4.0 builder image with OpenJDK 8.",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
                             "supports": "eap:7.4.0,javaee:8,java:8",
@@ -57,7 +57,7 @@
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK8 and RHEL8"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK8"
                         },
                         "referencePolicy": {
                             "type": "Local"
@@ -76,7 +76,7 @@
             "metadata": {
                 "name": "jboss-eap74-openjdk8-rhel8-runtime-openshift",
                 "annotations": {
-                    "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK 8 and RHEL8",
+                    "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK 8",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
                     "version": "7.4.0"
                 }
@@ -89,7 +89,7 @@
                     {
                         "name": "latest",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK 8 and RHEL8",
+                            "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK 8",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
                             "supports": "eap:7.4,javaee:8,java:8",
@@ -97,7 +97,7 @@
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK 8 (Runtime Image) and RHEL8"
+                            "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK 8 (Runtime Image)"
                         },
                         "referencePolicy": {
                             "type": "Local"
@@ -110,7 +110,7 @@
                     {
                         "name": "7.4.0",
                         "annotations": {
-                            "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 8 and RHEL8",
+                            "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 8",
                             "iconClass": "icon-eap",
                             "tags": "builder,eap,javaee,java,jboss,hidden",
                             "supports": "eap:7.4.0,javaee:8,java:8",
@@ -118,7 +118,7 @@
                             "sampleContextDir": "kitchensink",
                             "sampleRef": "7.4.x",
                             "version": "latest",
-                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 (Runtime Image) and RHEL8"
+                            "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 (Runtime Image)"
                         },
                         "referencePolicy": {
                             "type": "Local"


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-24491
Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)

I created a new file "eap74-openjdk8-rhel8-image-stream.json" using "eap74-openjdk8-image-stream.json" as source and change only the references from rhel7 to rhel8

diff eap74-openjdk8-rhel8-image-stream.json as rhel8-file eap74-openjdk8-image-stream.json as rhel7-file

rhel8-file= "name": "jboss-eap74-openjdk8-rhel8-openshift-image-streams",
rhel7-file= "name": "jjboss-eap74-openjdk8-openshift-image-streams",

rhel8-file= "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0 with OpenJDK 8 and RHEL 8",
rhel7-file= "description": "ImageStream definition for JBoss Enterprise Application Platform 7.4.0 with OpenJDK 8",

rhel8-file= "name": "jboss-eap74-openjdk8-rhel8-openshift",
rhel7-file= "name": "jboss-eap74-openjdk8-openshift",

rhel8-file= "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 and RHEL 8",
rhel7-file= "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8",

rhel8-file= "description": "The latest available build of JBoss EAP 7.4 builder image with OpenJDK 8 and RHEL8.",
rhel7-file= "description": "The latest available build of JBoss EAP 7.4 builder image with OpenJDK 8.",

rhel8-file= "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK8 and RHEL 8"
rhel7-file= "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK8"

rhel8-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
rhel7-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel7:latest"

rhel8-file= "description": "The latest available build of JBoss EAP 7.4.0 builder image with OpenJDK 8 and RHEL8.",
rhel7-file= "description": "The latest available build of JBoss EAP 7.4.0 builder image with OpenJDK 8.",

rhel8-file= "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK8 and RHEL8"
rhel7-file= "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK8"

rhel8-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel8:latest"
rhel7-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-openshift-rhel7:latest"

rhel8-file= "name": "jboss-eap74-openjdk8-rhel8-runtime-openshift",
rhel7-file= "name": "jboss-eap74-openjdk8-runtime-openshift",

rhel8-file= "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK 8 and RHEL8",
rhel7-file= "openshift.io/display-name": "JBoss EAP 7.4.0 Runtime Image with OpenJDK 8",

rhel8-file= "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK 8 and RHEL8",
rhel7-file= "description": "The latest available build of JBoss EAP 7.4 runtime image with OpenJDK 8",

rhel8-file= "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK 8 (Runtime Image) and RHEL8"
rhel7-file= "openshift.io/display-name": "JBoss EAP 7.4 with OpenJDK 8 (Runtime Image)"

rhel8-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel8:latest"
rhel7-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel7:latest"

rhel8-file= "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 8 and RHEL8",
rhel7-file= "description": "The latest available build of JBoss EAP 7.4.0 runtime image with OpenJDK 8",

rhel8-file= "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 (Runtime Image) and RHEL8"
rhel7-file= "openshift.io/display-name": "JBoss EAP 7.4.0 with OpenJDK 8 (Runtime Image)"

rhel8-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel8:latest"
rhel7-file= "name": "registry.redhat.io/jboss-eap-7/eap74-openjdk8-runtime-openshift-rhel7:latest"